### PR TITLE
[wip] Markdown support

### DIFF
--- a/bin/documentation.js
+++ b/bin/documentation.js
@@ -4,8 +4,16 @@ var documentation = require('../'),
   JSONStream = require('JSONStream'),
   path = require('path');
 
+var formatters = {
+  json: JSONStream.stringify(),
+  md: require('../output/md/index.js')()
+};
+
 var yargs = require('yargs')
   .usage('Usage: $0 <command> [options]')
+  .alias('f', 'format')
+  .describe('format', 'output format: one of json md html')
+  .default('format', 'json', 'raw data as JSON')
   .example('$0 foo.js', 'parse documentation in a given file'),
   argv = yargs.argv;
 
@@ -21,6 +29,12 @@ if (argv._.length > 0) {
   }
 }
 
+var formatterStream = formatters[ argv.format ];
+if (formatterStream === undefined) {
+  yargs.showHelp();
+  throw new Error('formatter stream type unknown');
+}
+
 documentation(inputs)
-  .pipe(JSONStream.stringify())
+  .pipe(formatterStream)
   .pipe(process.stdout);

--- a/output/md/index.js
+++ b/output/md/index.js
@@ -1,0 +1,47 @@
+var through = require('through'),
+  table = require('markdown-table');
+
+function tagsByType(data, type) {
+  return data.tags.filter(function (tag) {
+    return (tag.title === type);
+  });
+}
+
+function tagByTypes(data, types) {
+  for (var i = 0; i < types.length; i++) {
+    var tags = tagsByType(data, types[ i ]);
+    if (tags.length) return tags[ 0 ];
+  }
+}
+
+function removeNewlines(str) {
+  return str.replace('\n', ' ');
+}
+
+module.exports = function () {
+
+  function markdownGeneratorStream(data) {
+
+    var title = tagByTypes(data, [ 'name', 'alias', 'function', 'func', 'method' ]);
+
+    if (title) {
+      this.push('## ' + title.name + '\n\n');
+    }
+
+    var parameters = tagsByType(data, 'param');
+
+    if (parameters.length) {
+      this.push(table([[ 'name', 'description' ]]
+        .concat(parameters.map(function (parameter) {
+          return [
+            '`' + parameter.name + '`',
+            removeNewlines(parameter.description)
+          ];
+        }))));
+    }
+
+    this.push('\n\n' + data.description + '\n\n');
+  }
+
+  return through(markdownGeneratorStream);
+};

--- a/output/md/index.js
+++ b/output/md/index.js
@@ -23,13 +23,11 @@ module.exports = function () {
   function markdownGeneratorStream(data) {
 
     var title = tagByTypes(data, [ 'name', 'alias', 'function', 'func', 'method' ]);
-
     if (title) {
       this.push('## ' + title.name + '\n\n');
     }
 
     var parameters = tagsByType(data, 'param');
-
     if (parameters.length) {
       this.push(table([[ 'name', 'description' ]]
         .concat(parameters.map(function (parameter) {
@@ -38,6 +36,11 @@ module.exports = function () {
             removeNewlines(parameter.description)
           ];
         }))));
+    }
+
+    var example = tagByTypes(data, ['example']);
+    if (example) {
+      this.push('```js\n' + example.description + '\n```');
     }
 
     this.push('\n\n' + data.description + '\n\n');

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "doctrine": "^0.6.4",
     "esprima": "^2.1.0",
     "extend": "^2.0.0",
+    "markdown-table": "^0.3.2",
     "module-deps": "^3.7.2",
     "through": "^2.3.6",
     "through2": "^0.6.3",

--- a/test/bin.js
+++ b/test/bin.js
@@ -1,8 +1,11 @@
 'use strict';
 
 var test = require('tape'),
+  fs = require('fs'),
   path = require('path'),
   exec = require('child_process').exec;
+
+var UPDATE = !!process.env.UPDATE;
 
 function documentation(args, options, callback) {
   if (!callback) {
@@ -18,14 +21,25 @@ function documentation(args, options, callback) {
 
   exec(args.join(' '), options, function (err, stdout, stderr) {
     if (err) return callback(err, stdout, stderr);
-    callback(err, JSON.parse(stdout), stderr);
+    callback(err, stdout, stderr);
   });
 }
 
 test('documentation binary', function (t) {
   documentation(['fixture/simple.input.js'], function (err, data) {
     t.error(err);
-    t.equal(data.length, 1, 'simple has no dependencies');
+    t.equal(JSON.parse(data).length, 1, 'simple has no dependencies');
+    t.end();
+  });
+});
+
+test('markdown output', function (t) {
+  documentation([ 'fixture/simple.input.js', '-f', 'md' ], function (err, data) {
+    t.error(err);
+    var outputfile = path.join(__dirname, 'fixture', 'simple.output.md');
+    if (UPDATE) fs.writeFileSync(outputfile, data);
+    var expect = fs.readFileSync(outputfile, 'utf8');
+    t.equal(data, expect, 'simple has no dependencies');
     t.end();
   });
 });
@@ -33,7 +47,7 @@ test('documentation binary', function (t) {
 test('defaults to parsing package.json main', function (t) {
   documentation([], { cwd: path.join(__dirname, '..') }, function (err, data) {
     t.error(err);
-    t.ok(data.length, 'we document ourself');
+    t.ok(JSON.parse(data).length, 'we document ourself');
     t.end();
   });
 });

--- a/test/fixture/example.input.js
+++ b/test/fixture/example.input.js
@@ -1,0 +1,11 @@
+/**
+ * This function returns the number one.
+ * @return {Number} numberone
+ * @example
+ * var hopeitisone = getOne();
+ * hopeitisone++;
+ */
+function getOne() {
+  // this returns 1
+  return 1;
+}

--- a/test/fixture/example.output.json
+++ b/test/fixture/example.output.json
@@ -1,0 +1,37 @@
+[
+  {
+    "description": "This function returns the number one.",
+    "tags": [
+      {
+        "title": "return",
+        "description": "numberone",
+        "type": {
+          "type": "NameExpression",
+          "name": "Number"
+        }
+      },
+      {
+        "title": "example",
+        "description": "var hopeitisone = getOne();\nhopeitisone++;"
+      },
+      {
+        "title": "name",
+        "name": "getOne"
+      }
+    ],
+    "context": {
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 9
+        },
+        "end": {
+          "line": 8,
+          "column": 15
+        }
+      },
+      "file": "fixture/example.input.js",
+      "code": "function getOne() {\n  // this returns 1\n  return 1;\n}"
+    }
+  }
+]

--- a/test/fixture/simple.output.md
+++ b/test/fixture/simple.output.md
@@ -1,6 +1,8 @@
 ## exports
 
-
+undefined
+```js
+exports```
 
 This function returns the number one.
 

--- a/test/fixture/simple.output.md
+++ b/test/fixture/simple.output.md
@@ -1,0 +1,6 @@
+## exports
+
+
+
+This function returns the number one.
+

--- a/test/fixture/simple.output.md
+++ b/test/fixture/simple.output.md
@@ -1,8 +1,6 @@
 ## exports
 
-undefined
-```js
-exports```
+
 
 This function returns the number one.
 


### PR DESCRIPTION
* Supports titles
* Supports parameter tables
* Adds a single test case
* Adds option to `documentation` binary
* [ ] Format type specifiers properly, including optionals
* [ ] Add more tests
* [x] Output `@example`
* [ ] Output `@returns`

Thinking about this, it may make sense to do the kinds of parsing we already know people will want further up in the API to separate it from formatting: so, for instance, you could drop into a template and easily be able to iterate through parameter tags.