### PR TITLE
Add pivot filter

### DIFF
--- a/filter/pivot.js
+++ b/filter/pivot.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var through = require('through'),
+  extend = require('extend');
+
+/**
+ * Create a transform stream that pivots tags from an array-of-objects to an object-of-arrays.
+ *
+ * For example, given the input object:
+ *
+ *     { tags: [
+ *       { title: "name", name: "..." },
+ *       { title: "return", description: "..." },
+ *       { title: "example", description: "example 1" }
+ *       { title: "example", description: "example 2" }
+ *     ]}
+ *
+ * The output object will be:
+ *
+ *     { tags: {
+ *       name: [{ title: "name", name: "..." }],
+ *       return: [{ title: "return", description: "..." }],
+ *       example: [{ title: "example", description: "example 1" }, { title: "example", description: "example 2" }]
+ *     }}
+ *
+ * @name pivot
+ * @return {stream.Transform}
+ */
+module.exports = function() {
+  return through(function(comment) {
+    this.push(extend({}, comment, {tags: pivot(comment.tags)}));
+  });
+};
+
+function pivot(tags) {
+  return tags.reduce(function(result, tag) {
+    var title = tag.title,
+      value = result[title];
+
+    if (!value) {
+      value = result[title] = [];
+    }
+
+    value.push(tag);
+    return result;
+  }, {});
+};

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "a documentation generator",
   "main": "index.js",
   "scripts": {
-    "test": "eslint index.js test/*.js && tape test/*.js",
-    "cover": "istanbul cover tape test/*.js --dir $CIRCLE_ARTIFACTS"
+    "test": "eslint index.js test/*.js test/filter/*.js && tape test/*.js test/filter/*.js",
+    "cover": "istanbul cover tape test/*.js test/filter/*.js --dir $CIRCLE_ARTIFACTS"
   },
   "bin": {
     "documentation": "./bin/documentation.js"

--- a/test/filter/pivot.js
+++ b/test/filter/pivot.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var test = require('prova'),
+  pivot = require('../../filter/pivot'),
+  concat = require('concat-stream');
+
+test('pivots singular tags', function (t) {
+  var stream = pivot();
+
+  stream.pipe(concat(function (data) {
+    t.deepEqual(data, [{
+      tags: {
+        name: [{ title: 'name', 'name': '...' }],
+        example: [{ title: 'example', description: '1' }]
+      }
+    }]);
+    t.end();
+  }));
+
+  stream.end({ tags: [ { title: 'name', name: '...' }, { title: 'example', description: '1' } ] });
+});
+
+test('pivots multiple tags', function (t) {
+  var stream = pivot();
+
+  stream.pipe(concat(function (data) {
+    t.deepEqual(data, [{
+      tags: {
+        example: [ { title: 'example', description: '1' }, {
+          title: 'example',
+          description: '2'
+        } ]
+      }
+    }]);
+    t.end();
+  }));
+
+  stream.end({ tags: [ { title: 'example', description: '1' }, { title: 'example', description: '2' } ] });
+});


### PR DESCRIPTION
This is a transform stream that pivots tags from an array-of-objects to
an object-of-arrays. The latter is usually a more convenient interface
for downstream processors.