### PR TITLE
Create stream that parses Markdown in JSDoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "extend": "^2.0.0",
     "handlebars": "^3.0.0",
     "module-deps": "^3.7.3",
+    "remarkable": "^1.6.0",
     "through": "^2.3.6",
     "traverse": "^0.6.6",
     "yargs": "^3.5.4"

--- a/streams/html.js
+++ b/streams/html.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var through = require('through'),
+  Remarkable = require('remarkable'),
+  extend = require('extend');
+
+var defaultTags = ['author', 'classdesc', 'description',
+  'param', 'property', 'returns', 'see', 'throws'];
+
+/**
+ * Create a transform stream that parses Markdown in the 'description'
+ * tag and formats it as HTML.
+ *
+ * @param {Object} markdownOptions Options given to the Remarkable Markdown parser.
+ * @param {Array<String>} [overrideTags=author,classdesc,description,param,property,returns,see,throws]
+ * Tags which will be parsed and translated.
+ * @name markdown
+ * @return {stream.Transform}
+ */
+module.exports = function (opts, overrideTags) {
+  var tagsToParse = overrideTags || defaultTags;
+  var md = new Remarkable(opts);
+  return through(function (comment) {
+
+    var description = (tagsToParse.indexOf('description') !== -1 &&
+      comment.description) ? {
+      description: md.render(comment.description)
+    } : {};
+
+    var parsedTags = comment.tags ? {
+      tags: comment.tags.map(function (tag) {
+        return tagsToParse.indexOf(tag.title) !== -1 ?
+          extend({}, tag, {
+            description: md.render(tag.description)
+          }) : tag;
+      })
+    } : {};
+
+    this.push(extend({}, comment, parsedTags, description));
+  });
+};

--- a/test/streams/html.js
+++ b/test/streams/html.js
@@ -1,0 +1,89 @@
+'use strict';
+
+var test = require('prova'),
+  html = require('../../streams/html'),
+  concat = require('concat-stream');
+
+test('normalizes tags', function (t) {
+  var stream = html();
+
+  stream.pipe(concat(function (data) {
+    t.deepEqual(data, [{
+      'description': '<p><strong>this is markdown</strong></p>\n',
+      'tags': [{
+        'title': 'returns',
+        'description': '<p>numberone or <a href="http://google.com">google</a></p>\n',
+        'type': {
+          'type': 'NameExpression',
+          'name': 'Number'
+        }
+      }]
+    }]);
+    t.end();
+  }));
+
+  stream.end({
+    description: '**this is markdown**',
+    tags: [
+      {
+        'title': 'returns',
+        'description': 'numberone or [google](http://google.com)',
+        'type': {
+          'type': 'NameExpression',
+          'name': 'Number'
+        }
+      }
+    ]
+  });
+});
+
+test('opt-out of param parsing', function (t) {
+  var stream = html({}, ['description']);
+
+  stream.pipe(concat(function (data) {
+    t.deepEqual(data, [{
+      'description': '<p><strong>this is markdown</strong></p>\n',
+      'tags': [{
+        'title': 'returns',
+        'description': 'numberone or [google](http://google.com)',
+        'type': {
+          'type': 'NameExpression',
+          'name': 'Number'
+        }
+      }]
+    }]);
+    t.end();
+  }));
+
+  stream.end({
+    description: '**this is markdown**',
+    tags: [
+      {
+        'title': 'returns',
+        'description': 'numberone or [google](http://google.com)',
+        'type': {
+          'type': 'NameExpression',
+          'name': 'Number'
+        }
+      }
+    ]
+  });
+});
+
+test('passing options to remarkable', function (t) {
+  var stream = html({
+    linkify: true
+  });
+
+  stream.pipe(concat(function (data) {
+    t.deepEqual(data, [{
+      'description': '<ul>\n<li><a href="http://foo.com/">http://foo.com/</a></li>\n</ul>\n'
+    }]);
+    t.end();
+  }));
+
+  stream.end({
+    description: '+ http://foo.com/'
+  });
+});
+


### PR DESCRIPTION
Fixes #12

This uses remarkable behind the scenes. Before merge,
I want to figure out how to make the naming of the streams
that

* Output HTML
* Parse Markdown into HTML
* Emit Markdown

Straightforward