### PR TITLE
Add `queue-async` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "sqlite3": "^3.0.5",
     "stream-combiner": "^0.2.1",
     "concat-stream": "^1.4.7",
+    "queue-async": "^1.0.7",
     "through": "^2.3.6",
     "traverse": "^0.6.6",
     "vinyl": "^0.4.6",


### PR DESCRIPTION
Resolves

```
documentation -h
module.js:338
    throw err;
          ^
Error: Cannot find module 'queue-async'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/deedubs/.npm-packages/lib/node_modules/documentation/streams/output/docset.js:6:11)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)

```