### PR TITLE
Fixes for sorting

### DIFF
--- a/share/html/index.hbs
+++ b/share/html/index.hbs
@@ -19,18 +19,18 @@
                 class='regular block'>
                 <code>{{name}}</code>
               </a>
-              {{#each members.instance}}
-                <a
-                  href='#{{permalink}}'
-                  class='button-indent regular block'>
-                  <code>#{{name}}</code>
-                </a>
-              {{/each}}
               {{#each members.static}}
                 <a
                   href='#{{permalink}}'
                   class='button-indent regular block'>
                   <code>.{{name}}</code>
+                </a>
+              {{/each}}
+              {{#each members.instance}}
+                <a
+                  href='#{{permalink}}'
+                  class='button-indent regular block'>
+                  <code>#{{name}}</code>
                 </a>
               {{/each}}
             {{/each}}

--- a/share/html/section.hbs
+++ b/share/html/section.hbs
@@ -56,16 +56,16 @@
 {{#each examples ~}}<pre>{{{.}}}</pre>{{/each}}
   {{/if}}
 
-  {{#if members.instance}}
-    {{#each members.instance}}
+  {{#if members.static}}
+    {{#each members.static}}
       <div class='section-indent'>
 {{> section}}
       </div>
     {{/each}}
   {{/if}}
 
-  {{#if members.static}}
-    {{#each members.static}}
+  {{#if members.instance}}
+    {{#each members.instance}}
       <div class='section-indent'>
 {{> section}}
       </div>

--- a/streams/github.js
+++ b/streams/github.js
@@ -55,8 +55,8 @@ module.exports = function () {
         comment.context.file.replace(root + '/', '') +
         '#L' + comment.context.loc.start.line + '-' +
         'L' + comment.context.loc.end.line;
-      this.resume();
       this.push(comment);
+      this.resume();
     }.bind(this));
   });
 };

--- a/streams/hierarchy.js
+++ b/streams/hierarchy.js
@@ -34,6 +34,11 @@ module.exports = function () {
  */
 function inferHierarchy(comments) {
   var nameIndex = {}, i;
+
+  // We're going to iterate comments in reverse to generate the memberships so
+  // to avoid reversing the sort order we reverse the array for the name index.
+  comments.reverse();
+
   // First, create a fast lookup index of Namespace names
   // that might be used in memberof tags, and let all objects
   // have members
@@ -57,6 +62,10 @@ function inferHierarchy(comments) {
       }
     }
   }
+
+  // Now the members are in the right order but the root comments are reversed
+  // so we reverse once more.
+  comments.reverse();
 
   /**
    * Add paths to each comment, making it possible to generate permalinks

--- a/streams/sort.js
+++ b/streams/sort.js
@@ -18,6 +18,6 @@ module.exports = function () {
   }
 
   return sort(function (a, b) {
-    return getSortKey(a) > getSortKey(b);
+    return getSortKey(a).localeCompare(getSortKey(b));
   });
 };

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -1467,9 +1467,9 @@ section:target {
                 <code>Klass</code>
               </a>
                 <a
-                  href='#klass/getfoo'
+                  href='#klass/magic-number'
                   class='button-indent regular block'>
-                  <code>#getFoo</code>
+                  <code>.MAGIC_NUMBER</code>
                 </a>
                 <a
                   href='#klass/isclass'
@@ -1477,9 +1477,9 @@ section:target {
                   <code>.isClass</code>
                 </a>
                 <a
-                  href='#klass/magic-number'
+                  href='#klass/getfoo'
                   class='button-indent regular block'>
-                  <code>.MAGIC_NUMBER</code>
+                  <code>#getFoo</code>
                 </a>
               <a
                 href='#bar'
@@ -1506,34 +1506,24 @@ section:target {
 
 
       <div class='section-indent'>
-<section id='klass/getfoo'class='mt2 mb2 py1 px3 keyline-top'>
+<section id='klass/magic-number'class='mt2 mb2 py1 px3 keyline-top'>
   <h3 class='regular'>
-    <a class='black' href='#klass/getfoo'>
+    <a class='black' href='#klass/magic-number'>
       <code>
-        getFoo<span class='gray'></span>
+        MAGIC_NUMBER<span class='gray'></span>
       </code>
     </a>
   </h3>
-  <p>Get this Klass's foo</p>
+  <p>A magic number that identifies this Klass.</p>
 
 
 
-      <h4>Returns</h4>
-      <code><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code></code>
-      :
-      <span class='force-inline'>
-        <p>foo</p>
 
-      </span>
-
-    <h4>Examples</h4>
-<pre>foo.getFoo();</pre>
 
 
 
 </section>
       </div>
-
       <div class='section-indent'>
 <section id='klass/isclass'class='mt2 mb2 py1 px3 keyline-top'>
   <h3 class='regular'>
@@ -1576,20 +1566,30 @@ This is a <a href="doesnot"><code>link to something that does not exist</code></
 
 </section>
       </div>
+
       <div class='section-indent'>
-<section id='klass/magic-number'class='mt2 mb2 py1 px3 keyline-top'>
+<section id='klass/getfoo'class='mt2 mb2 py1 px3 keyline-top'>
   <h3 class='regular'>
-    <a class='black' href='#klass/magic-number'>
+    <a class='black' href='#klass/getfoo'>
       <code>
-        MAGIC_NUMBER<span class='gray'></span>
+        getFoo<span class='gray'></span>
       </code>
     </a>
   </h3>
-  <p>A magic number that identifies this Klass.</p>
+  <p>Get this Klass's foo</p>
 
 
 
+      <h4>Returns</h4>
+      <code><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code></code>
+      :
+      <span class='force-inline'>
+        <p>foo</p>
 
+      </span>
+
+    <h4>Examples</h4>
+<pre>foo.getFoo();</pre>
 
 
 


### PR DESCRIPTION
Turned out to be more complicated than I thought, there were four changes:

- sorting was broken (the comparison function was returning true/false instead
  of 1, 0, -1)
- the github stream was reversing the order of comments (a bizarre consequence
  of calling `resume()` before `push()`)
- the hierarchy stream was reversing the order of members but left the order of
  the roots intact
- I moved static members above instance ones (my reasoning being that there are
  usually fewer static members and that often they're used for initialization
  of new objects so the top is a good place for them)