### PR TITLE
Don't run tests with the user's global .eslintrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "a documentation generator",
   "main": "index.js",
   "scripts": {
-    "test": "eslint index.js test/*.js test/streams/*.js && prova test/*.js test/streams/*.js",
+    "test": "eslint --no-eslintrc -c .eslintrc index.js test/*.js test/streams/*.js && prova test/*.js test/streams/*.js",
     "cover": "istanbul cover prova test/*.js test/streams/*.js --dir $CIRCLE_ARTIFACTS"
   },
   "bin": {


### PR DESCRIPTION
If the user has a `$HOME/.eslintrc` it will be read and merged with the
`.eslintrc` in this directory; this pull request disables that behavior so that
only the project rules are applied.