### PR TITLE
Add a rudimentary test for @typedef

### DIFF
--- a/test/fixture/typedef.input.js
+++ b/test/fixture/typedef.input.js
@@ -1,0 +1,8 @@
+/**
+ * A type definition.
+ * @name MyType
+ * @typedef {Object} MyType
+ * @property {number} prop1 - one property
+ * @property {string} prop2 - another property
+ */
+

--- a/test/fixture/typedef.output.custom.md
+++ b/test/fixture/typedef.output.custom.md
@@ -1,0 +1,6 @@
+## `MyType`
+
+A type definition.
+
+
+

--- a/test/fixture/typedef.output.json
+++ b/test/fixture/typedef.output.json
@@ -1,0 +1,93 @@
+[
+  {
+    "description": "A type definition.",
+    "tags": [
+      {
+        "title": "name",
+        "description": null,
+        "lineNumber": 2,
+        "name": "MyType"
+      },
+      {
+        "title": "typedef",
+        "description": "MyType",
+        "lineNumber": 3,
+        "type": {
+          "type": "NameExpression",
+          "name": "Object"
+        }
+      },
+      {
+        "title": "property",
+        "description": "one property",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        },
+        "name": "prop1"
+      },
+      {
+        "title": "property",
+        "description": "another property",
+        "lineNumber": 5,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "prop2"
+      },
+      {
+        "title": "kind",
+        "kind": "typedef"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 9,
+          "column": 0
+        },
+        "end": {
+          "line": 9,
+          "column": 0
+        }
+      },
+      "file": "fixture/typedef.input.js"
+    },
+    "name": "MyType",
+    "properties": [
+      {
+        "title": "property",
+        "description": "one property",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        },
+        "name": "prop1"
+      },
+      {
+        "title": "property",
+        "description": "another property",
+        "lineNumber": 5,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "prop2"
+      }
+    ],
+    "kind": "typedef"
+  }
+]

--- a/test/fixture/typedef.output.md
+++ b/test/fixture/typedef.output.md
@@ -1,0 +1,13 @@
+## `MyType`
+
+A type definition.
+
+
+| name | type | description |
+| ---- | ---- | ----------- |
+| `prop1` | `number` | one property |
+| `prop2` | `string` | another property |
+
+
+
+


### PR DESCRIPTION
@tmcw Added this in a super rudimentary format because I needed it for something. Couple of known issues I didn't have time to examine closely: 1) currently needs a `@name` tag, but presumably the name should be pulled off the `@typedef` tag (right?), and 2) if the typedef comment is at the end of a file, w/ no subsequent code node, it gets dropped.