### PR TITLE
md output: cleanly handle newlines in descriptions.

### DIFF
--- a/share/markdown.hbs
+++ b/share/markdown.hbs
@@ -10,7 +10,7 @@
 | name | type | description |
 | ---- | ---- | ----------- |
 {{#params}}
-| `{{name}}` | {{format_type type}} | {{inlines description}} |
+| `{{name}}` | {{format_type type}} | {{format_description description}} |
 {{/params}}
 {{/if}}
 
@@ -18,7 +18,7 @@
 | name | type | description |
 | ---- | ---- | ----------- |
 {{#properties}}
-| `{{name}}` | {{format_type type}} | {{inlines description}} |
+| `{{name}}` | {{format_type type}} | {{format_description description}} |
 {{/properties}}
 {{/if}}
 

--- a/streams/output/markdown.js
+++ b/streams/output/markdown.js
@@ -98,7 +98,11 @@ module.exports = function (opts) {
     }
   }
 
-  Handlebars.registerHelper('format_params', function(params) {
+  function inlines(string) {
+    return new Handlebars.SafeString(formatInlineTags(string));
+  }
+
+  Handlebars.registerHelper('format_params', function (params) {
     return new Handlebars.SafeString(formatParameters(params));
   });
 
@@ -106,9 +110,12 @@ module.exports = function (opts) {
     return new Handlebars.SafeString('`' + formatType(type) + '`');
   });
 
-  Handlebars.registerHelper('inlines', function (string) {
-    return new Handlebars.SafeString(formatInlineTags(string));
+  Handlebars.registerHelper('format_description', function (desc) {
+    var singleLine = (desc || '').replace(/\n/g, ' ');
+    return inlines(singleLine);
   });
+
+  Handlebars.registerHelper('inlines', inlines);
 
   return through(function (comment) {
     this.push(template(comment));

--- a/test/fixture/newline-in-description.input.js
+++ b/test/fixture/newline-in-description.input.js
@@ -1,0 +1,6 @@
+/**
+ * A function.
+ * @param a - The input to the function.
+ * I should be able to continue the description on a new line, and have it
+ * still work in the markdown table.
+ */

--- a/test/fixture/newline-in-description.output.custom.md
+++ b/test/fixture/newline-in-description.output.custom.md
@@ -1,0 +1,9 @@
+## ``
+
+A function.
+
+* `a`: The input to the function.
+I should be able to continue the description on a new line, and have it
+still work in the markdown table.
+
+

--- a/test/fixture/newline-in-description.output.json
+++ b/test/fixture/newline-in-description.output.json
@@ -1,0 +1,34 @@
+[
+  {
+    "description": "A function.",
+    "tags": [
+      {
+        "title": "param",
+        "description": "The input to the function.\nI should be able to continue the description on a new line, and have it\nstill work in the markdown table.",
+        "type": null,
+        "name": "a"
+      }
+    ],
+    "context": {
+      "loc": {
+        "start": {
+          "line": 7,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 0
+        }
+      },
+      "file": "fixture/newline-in-description.input.js"
+    },
+    "params": [
+      {
+        "title": "param",
+        "description": "The input to the function.\nI should be able to continue the description on a new line, and have it\nstill work in the markdown table.",
+        "type": null,
+        "name": "a"
+      }
+    ]
+  }
+]

--- a/test/fixture/newline-in-description.output.md
+++ b/test/fixture/newline-in-description.output.md
@@ -1,0 +1,13 @@
+## ``
+
+A function.
+
+### Parameters
+
+| name | type | description |
+| ---- | ---- | ----------- |
+| `a` | `` | The input to the function. I should be able to continue the description on a new line, and have it still work in the markdown table. |
+
+
+
+


### PR DESCRIPTION
Currently, a newline in a parameter description breaks the default parameters table output.  This is a quick fix for that.