### PR TITLE
Fix github stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sqlite3": "^3.0.5",
     "stream-splicer": "^1.3.1",
     "through": "^2.3.6",
+    "through2": "^1.1.1",
     "traverse": "^0.6.6",
     "vinyl": "^0.4.6",
     "vinyl-fs": "^1.0.0",

--- a/streams/github.js
+++ b/streams/github.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var through = require('through');
+var through2 = require('through2');
 var exec = require('child_process').exec;
 var path = require('path');
 var fs = require('fs');
@@ -47,16 +47,14 @@ function makeGetBase() {
  */
 module.exports = function () {
   var getBase = makeGetBase();
-  return through(function (comment) {
-    this.pause();
+  return through2.obj(function (comment, enc, callback) {
     getBase(comment.context.file, function (base, root) {
       comment.context.path = comment.context.file.replace(root + '/', '');
       comment.context.github = base +
         comment.context.file.replace(root + '/', '') +
         '#L' + comment.context.loc.start.line + '-' +
         'L' + comment.context.loc.end.line;
-      this.push(comment);
-      this.resume();
-    }.bind(this));
+      callback(null, comment);
+    });
   });
 };


### PR DESCRIPTION
It looks like `through` doesn't support asynchronous streams very well. In my
testing it looks like the github stream just stops a third of the way through
processing comments (but with no errors, it just drops the rest on the floor
and you get no output). Substituting `through2` works like a charm, though. :)

Fixes #81