### PR TITLE
User-defined sorting via config file

### DIFF
--- a/bin/documentation.js
+++ b/bin/documentation.js
@@ -39,6 +39,9 @@ var yargs = require('yargs')
   .alias('o', 'output')
   .default('o', 'stdout')
 
+  .describe('c', 'configuration file. an array defining explicit sort order')
+  .alias('c', 'config')
+
   .help('h')
   .alias('h', 'help')
 
@@ -86,10 +89,20 @@ if (argv.f === 'html' && argv.o === 'stdout') {
   throw new Error('The HTML output mode requires a destination directory set with -o');
 }
 
+if (argv.config) {
+  if (!fs.existsSync(path.resolve(argv.config))) {
+    yargs.showHelp();
+    throw new Error('No config file was found at ' + argv.config);
+  }
+
+  argv.config = JSON.parse(fs.readFileSync(path.resolve(argv.config)));
+}
+
 var docStream = documentation(inputs, {
     private: argv.private,
     transform: transform,
-    polyglot: argv.polyglot
+    polyglot: argv.polyglot,
+    config: argv.config
   })
   .pipe(argv.lint ? lint() : new PassThrough({ objectMode: true }))
   .pipe(argv.g ? github() : new PassThrough({ objectMode: true }))

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function (indexes, options) {
 
   return splicer.obj(
     inputStream.concat([
-    sort(),
+    sort(options.config),
     normalize(),
     flatten(),
     nestParams(),

--- a/streams/sort.js
+++ b/streams/sort.js
@@ -4,20 +4,34 @@ var sort = require('sort-stream');
  * Create a stream.Transform that sorts its input of comments
  * by the name tag, if any, and otherwise by filename.
  * @name sort
+ * @param {array} order an array of names that follow a user-defined order
  * @return {stream.Transform} a transform stream
  */
-module.exports = function () {
+module.exports = function (order) {
+  order = order || [];
 
   function getSortKey(comment) {
+    var key;
     for (var i = 0; i < comment.tags.length; i++) {
       if (comment.tags[i].title === 'name') {
-        return comment.tags[i].name;
+        key = comment.tags[i].name;
+        break;
       }
     }
-    return comment.context.file;
+    if (!key) key = comment.context.file;
+    return order.indexOf(key) > -1 ? order.indexOf(key) : key;
   }
 
   return sort(function (a, b) {
-    return getSortKey(a).localeCompare(getSortKey(b));
+    a = getSortKey(a);
+    b = getSortKey(b);
+
+    numa = typeof a === 'number';
+    numb = typeof b === 'number';
+
+    if (numa && numb) return a - b;
+    if (numa) return -1;
+    if (numb) return 1;
+    return a.localeCompare(b);
   });
 };

--- a/test/bin.js
+++ b/test/bin.js
@@ -2,7 +2,8 @@
 
 var test = require('prova'),
   path = require('path'),
-  exec = require('child_process').exec;
+  exec = require('child_process').exec,
+  fs = require('fs');
 
 function documentation(args, options, callback) {
   if (!callback) {
@@ -22,6 +23,13 @@ function documentation(args, options, callback) {
   });
 }
 
+function normalize(result) {
+  result.forEach(function (item) {
+    item.context.file = path.relative(__dirname, item.context.file);
+  });
+  return result;
+}
+
 test('documentation binary', function (t) {
   documentation(['fixture/simple.input.js'], function (err, data) {
     t.error(err);
@@ -34,6 +42,15 @@ test('defaults to parsing package.json main', function (t) {
   documentation([], { cwd: path.join(__dirname, '..') }, function (err, data) {
     t.error(err);
     t.ok(data.length, 'we document ourself');
+    t.end();
+  });
+});
+
+test('accepts config file', function (t) {
+  documentation(['fixture/sorting/input.js -c fixture/config.json'], function (err, data) {
+    t.error(err);
+    var expected = fs.readFileSync(path.resolve(__dirname, 'fixture', 'sorting/output.json'), 'utf8');
+    t.deepEqual(normalize(data), JSON.parse(expected), 'respected sort order from config file');
     t.end();
   });
 });

--- a/test/fixture/config.json
+++ b/test/fixture/config.json
@@ -1,0 +1,1 @@
+["bananas", "carrots", "apples"]

--- a/test/fixture/sorting/input.js
+++ b/test/fixture/sorting/input.js
@@ -1,0 +1,20 @@
+/**
+ * Apples are red
+ */
+var apples = function() {
+  return 'red';
+};
+
+/**
+ * Bananas are yellow
+ */
+var bananas = function() {
+  return 'yellow';
+};
+
+/**
+ * Carrots are awesome
+ */
+var carrots = function() {
+  return 'awesome';
+};

--- a/test/fixture/sorting/output.json
+++ b/test/fixture/sorting/output.json
@@ -1,0 +1,119 @@
+[
+  {
+    "description": "Bananas are yellow",
+    "tags": [
+      {
+        "title": "name",
+        "name": "bananas"
+      },
+      {
+        "title": "kind",
+        "kind": "function"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 10,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 11,
+          "column": 0
+        },
+        "end": {
+          "line": 13,
+          "column": 2
+        }
+      },
+      "file": "fixture/sorting/input.js",
+      "code": "var apples = function() {\n  return 'red';\n};\n\n/**\n * Bananas are yellow\n */\nvar bananas = function() {\n  return 'yellow';\n};\n\n/**\n * Carrots are awesome\n */\nvar carrots = function() {\n  return 'awesome';\n};"
+    },
+    "name": "bananas",
+    "kind": "function"
+  },
+  {
+    "description": "Carrots are awesome",
+    "tags": [
+      {
+        "title": "name",
+        "name": "carrots"
+      },
+      {
+        "title": "kind",
+        "kind": "function"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 0
+      },
+      "end": {
+        "line": 17,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 18,
+          "column": 0
+        },
+        "end": {
+          "line": 20,
+          "column": 2
+        }
+      },
+      "file": "fixture/sorting/input.js",
+      "code": "var apples = function() {\n  return 'red';\n};\n\n/**\n * Bananas are yellow\n */\nvar bananas = function() {\n  return 'yellow';\n};\n\n/**\n * Carrots are awesome\n */\nvar carrots = function() {\n  return 'awesome';\n};"
+    },
+    "name": "carrots",
+    "kind": "function"
+  },
+  {
+    "description": "Apples are red",
+    "tags": [
+      {
+        "title": "name",
+        "name": "apples"
+      },
+      {
+        "title": "kind",
+        "kind": "function"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 2
+        }
+      },
+      "file": "fixture/sorting/input.js",
+      "code": "var apples = function() {\n  return 'red';\n};\n\n/**\n * Bananas are yellow\n */\nvar bananas = function() {\n  return 'yellow';\n};\n\n/**\n * Carrots are awesome\n */\nvar carrots = function() {\n  return 'awesome';\n};"
+    },
+    "name": "apples",
+    "kind": "function"
+  }
+]

--- a/test/streams/sort.js
+++ b/test/streams/sort.js
@@ -1,0 +1,142 @@
+'use strict';
+
+var test = require('prova'),
+  concat = require('concat-stream'),
+  sort = require('../../streams/sort'),
+  stream = require('stream');
+
+test('sort stream alphanumeric', function (t) {
+  var input = new stream.PassThrough({ objectMode: true });
+
+  input
+    .pipe(sort())
+    .on('error', function (err) {
+      throw err;
+    })
+    .pipe(concat(function (deps) {
+      t.equal(
+        JSON.stringify(deps),
+        '[{"tags":[{"title":"name","name":"apples"}]},{"tags":[{"title":"name","name":"bananas"}]},{"tags":[{"title":"name","name":"carrot"}]}]'
+      );
+      t.end();
+    }));
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'apples' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'carrot' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'bananas' } ]
+  });
+
+  input.end();
+});
+
+test('sort stream with numbers', function (t) {
+  var input = new stream.PassThrough({ objectMode: true });
+
+  input
+    .pipe(sort())
+    .on('error', function (err) {
+      throw err;
+    })
+    .pipe(concat(function (deps) {
+      t.equal(
+        JSON.stringify(deps),
+        '[{"tags":[{"title":"name","name":"10"}]},{"tags":[{"title":"name","name":"2"}]},{"tags":[{"title":"name","name":"apples"}]},{"tags":[{"title":"name","name":"carrot"}]}]'
+      );
+      t.end();
+    }));
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'apples' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'carrot' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': '2' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': '10' } ]
+  });
+
+  input.end();
+});
+
+test('sort stream with explicit order for all', function (t) {
+  var input = new stream.PassThrough({ objectMode: true });
+
+  input
+    .pipe(sort(['apples', '2', 'carrot', '10']))
+    .on('error', function (err) {
+      throw err;
+    })
+    .pipe(concat(function (deps) {
+      t.equal(
+        JSON.stringify(deps),
+        '[{"tags":[{"title":"name","name":"apples"}]},{"tags":[{"title":"name","name":"2"}]},{"tags":[{"title":"name","name":"carrot"}]},{"tags":[{"title":"name","name":"10"}]}]'
+      );
+      t.end();
+    }));
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'apples' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'carrot' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': '2' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': '10' } ]
+  });
+
+  input.end();
+});
+
+test('sort stream with explicit order for some', function (t) {
+  var input = new stream.PassThrough({ objectMode: true });
+
+  input
+    .pipe(sort(['carrot', '10']))
+    .on('error', function (err) {
+      throw err;
+    })
+    .pipe(concat(function (deps) {
+      t.equal(
+        JSON.stringify(deps),
+        '[{"tags":[{"title":"name","name":"carrot"}]},{"tags":[{"title":"name","name":"10"}]},{"tags":[{"title":"name","name":"2"}]},{"tags":[{"title":"name","name":"apples"}]}]'
+      );
+      t.end();
+    }));
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'apples' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': 'carrot' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': '2' } ]
+  });
+
+  input.write({
+    tags: [ { 'title': 'name', 'name': '10' } ]
+  });
+
+  input.end();
+});


### PR DESCRIPTION
Took a stab at https://github.com/documentationjs/documentation/issues/100, allowing you to pass in an array of names as a JSON file:

```
documentation index.js -c ./config.json
```

I know there's some talk in the ticket about expanding the utility of a "config" file beyond simply sorting keys. The array is a way to start and take care of the sorting issue.

I wrote some tests but I'm not sure how well they fit into the overall test structure. I'm just starting to get a sense of the project.