### PR TITLE
Test a windows-compatible git finder. Fixes #133

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  post:
-    - npm run cover

--- a/lib/find_git.js
+++ b/lib/find_git.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var path = require('path');
+var fs = require('fs');
+
+/**
+ * Given a full path to a single file, iterate upwards through the filesystem
+ * to find a directory with a .git file indicating that it is a git repository
+ * @param {string} filename
+ * @returns {string} repository path
+ */
+function findGit(filename) {
+  var paths = filename.split(path.sep);
+  for (var i = paths.length - 1; i > 0; i--) {
+    var p = path.resolve(paths.slice(0, i).join(path.sep) + path.sep + '.git');
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+}
+
+module.exports = findGit;

--- a/streams/github.js
+++ b/streams/github.js
@@ -3,19 +3,8 @@
 var through2 = require('through2');
 var exec = require('child_process').exec;
 var path = require('path');
-var fs = require('fs');
 var urlFromGit = require('github-url-from-git');
-
-function findGit(filename, relative) {
-  relative = relative || '.git';
-  var newPath = path.resolve(filename, relative);
-  if (fs.existsSync(newPath)) {
-    return newPath;
-  } else if (newPath === '/') {
-    return null;
-  }
-  return findGit(filename, '../' + relative);
-}
+var findGit = require('../lib/find_git');
 
 function makeGetBase() {
   var base, root;


### PR DESCRIPTION
@HansHammel 

This should address #133 by fixing the path-separator issue that crops up on Windows. Any chance you can test by running this branch?