### PR TITLE
Simplify error parsing by attaching errors to comments

### DIFF
--- a/bin/documentation.js
+++ b/bin/documentation.js
@@ -8,6 +8,7 @@ var documentation = require('../'),
   path = require('path'),
   fs = require('fs'),
   vfs = require('vinyl-fs'),
+  formatError = require('../lib/error'),
   loadConfig = require('../lib/load_config.js'),
   args = require('../lib/args.js'),
   argv = args.parse(process.argv.slice(2));
@@ -65,13 +66,15 @@ documentation(inputs, {
   polyglot: argv.polyglot,
   order: config.order || [],
   shallow: argv.shallow
-}, function (err, result, lints) {
+}, function (err, result) {
   if (err) {
     throw err;
   }
 
-  lints.forEach(function (err) {
-    console.error(err);
+  result.forEach(function (comment) {
+    comment.errors.forEach(function (error) {
+      console.error(formatError(comment, error));
+    });
   });
 
   formatter(result, formatterOptions, function (err, output) {

--- a/index.js
+++ b/index.js
@@ -51,8 +51,7 @@ module.exports = function (indexes, options, callback) {
 
   return inputStream.pipe(concat(function (inputs) {
     try {
-
-      var docs = inputs
+      callback(null, inputs
         .filter(filterJS)
         .reduce(function (memo, file) {
           return memo.concat(parse(file));
@@ -66,9 +65,7 @@ module.exports = function (indexes, options, callback) {
           return comment;
         })
         .sort(sort.bind(undefined, options.order))
-        .filter(filterAccess.bind(undefined, options.private ? [] : undefined));
-
-      callback(null, docs);
+        .filter(filterAccess.bind(undefined, options.private ? [] : undefined)));
     } catch (e) {
       callback(e);
     }

--- a/index.js
+++ b/index.js
@@ -52,15 +52,12 @@ module.exports = function (indexes, options, callback) {
   return inputStream.pipe(concat(function (inputs) {
     try {
 
-      var errors = [];
-
       var docs = inputs
         .filter(filterJS)
         .reduce(function (memo, file) {
           return memo.concat(parse(file));
         }, [])
         .map(function (comment) {
-          comment.errors = [];
           // compose nesting & membership to avoid intermediate arrays
           comment = nestParams(inferMembership(inferKind(inferName(lint(comment)))));
           if (options.github) {
@@ -71,7 +68,7 @@ module.exports = function (indexes, options, callback) {
         .sort(sort.bind(undefined, options.order))
         .filter(filterAccess.bind(undefined, options.private ? [] : undefined));
 
-      callback(null, docs, errors);
+      callback(null, docs);
     } catch (e) {
       callback(e);
     }

--- a/lib/error.js
+++ b/lib/error.js
@@ -6,15 +6,14 @@ var path = require('path');
 /**
  * Format an error message regarding a comment, prefixed with file name and line number.
  *
- * @param {Tag|null} tag location in a javascript file, if any
  * @param {Comment} comment a parsed comment
  * @param {string} error error message a string
  * @param {...*} varags format arguments
  * @returns {undefined} outputs to stderr
  */
-module.exports = function (tag, comment, error) {
+module.exports = function (comment, error) {
   var relativePath = path.relative(process.cwd(), comment.context.file),
-    lineNumber = (tag ? tag.lineNumber : 0) + comment.loc.start.line;
+    lineNumber = comment.loc.start.line;
 
   return format.apply(format, ['%s:%d: ' + error, relativePath, lineNumber]
     .concat(Array.prototype.slice.call(arguments, 3)));

--- a/lib/hierarchy.js
+++ b/lib/hierarchy.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var error = require('../lib/error');
-
 /**
  * Add paths to each comment, making it possible to generate permalinks
  * that differentiate between instance functions with the same name but

--- a/lib/hierarchy.js
+++ b/lib/hierarchy.js
@@ -60,9 +60,7 @@ function inferHierarchy(comments) {
     var parent = nameIndex[comment.memberof];
 
     if (!parent) {
-      var err = error(null, comment, 'memberof reference to %s not found', comment.memberof);
-      comment.errors = (comment.errors || []).concat(err);
-      console.error(err);
+      comment.errors.push('memberof reference to ' + comment.memberof + ' not found');
       continue;
     }
 
@@ -73,9 +71,7 @@ function inferHierarchy(comments) {
 
     default:
       if (!comment.scope) {
-        var err2 = error(null, comment, 'found memberof but no @scope, @static, or @instance tag');
-        comment.errors = (comment.errors || []).concat(err2);
-        console.error(err2);
+        comment.errors.push('found memberof but no @scope, @static, or @instance tag');
         continue;
       }
       parent.members[comment.scope].push(comment);

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -24,7 +24,8 @@ module.exports = function (comment) {
   comment.tags.forEach(function (tag) {
     function nameInvariant(name) {
       if (CANONICAL[name]) {
-        errors.push(error(tag, comment, 'type %s found, %s is standard', name, CANONICAL[name]));
+        comment.errors.push(
+          'type ' + name + ' found, ' + CANONICAL[name] + ' is standard');
       }
     }
 
@@ -48,6 +49,5 @@ module.exports = function (comment) {
       checkCanonical(tag.type);
     }
   });
-  return errors;
+  return comment;
 };
-

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var error = require('../lib/error');
-
 var CANONICAL = {
   'String': 'string',
   'Boolean': 'boolean',

--- a/lib/nest_params.js
+++ b/lib/nest_params.js
@@ -30,10 +30,8 @@ module.exports = function (comment) {
     if (parts.length > 1) {
       var parent = index[parts[0]];
       if (parent === undefined) {
-        console.error(
-          '@param %s\'s parent %s not found',
-          param.name,
-          parts[0]);
+        result.errors.push(
+          '@param ' + param.name + '\'s parent ' + parts[0] + ' not found');
         result.params.push(param);
         return;
       }

--- a/lib/output/json.js
+++ b/lib/output/json.js
@@ -13,5 +13,14 @@
  * @return {undefined} calls callback
  */
 module.exports = function (comments, opts, callback) {
+
+  opts = opts || {};
+
+  if (!opts.preserveErrors) {
+    comments.forEach(function (comment) {
+      delete comment.errors;
+    });
+  }
+
   return callback(null, JSON.stringify(comments, null, 2));
 };

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -30,6 +30,7 @@ module.exports = function (comment, loc, context) {
 
   result.loc = loc;
   result.context = context;
+  result.errors = [];
 
   var i = 0;
   var errors = [];
@@ -37,7 +38,7 @@ module.exports = function (comment, loc, context) {
     var tag = result.tags[i];
     if (tag.errors) {
       for (var j = 0; j < tag.errors.length; j++) {
-        errors.push(error(tag, result, tag.errors[j]));
+        result.errors.push(tag.errors[j]);
       }
       result.tags.splice(i, 1);
     } else {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -33,7 +33,6 @@ module.exports = function (comment, loc, context) {
   result.errors = [];
 
   var i = 0;
-  var errors = [];
   while (i < result.tags.length) {
     var tag = result.tags[i];
     if (tag.errors) {
@@ -46,11 +45,5 @@ module.exports = function (comment, loc, context) {
     }
   }
 
-  result = flatten(normalize(result));
-
-  if (errors.length) {
-    result.errors = errors;
-  }
-
-  return result;
+  return flatten(normalize(result));
 };

--- a/test/lib/error.js
+++ b/test/lib/error.js
@@ -20,8 +20,7 @@ test('error', function (t) {
     }
   };
 
-  t.deepEqual(error(tag, comment, 'test'), 'file.js:3: test');
-  t.deepEqual(error(tag, comment, '%s', 'test'), 'file.js:3: test');
+  t.deepEqual(error(comment, 'test'), 'file.js:1: test');
 
   t.end();
 });

--- a/test/lib/hierarchy.js
+++ b/test/lib/hierarchy.js
@@ -94,6 +94,6 @@ test('hierarchy - missing memberof', function (t) {
   });
 
   t.equal(result.length, 1);
-  t.equal(result[0].errors.length, 1);
+  t.equal(result[0].errors[0], 'memberof reference to DoesNotExist not found', 'correct error message');
   t.end();
 });

--- a/test/lib/lint.js
+++ b/test/lib/lint.js
@@ -22,9 +22,9 @@ test('lint', function (t) {
      * @param {array} bar
      */
     return 0;
-  }), [
-    'input.js:3: type String found, string is standard',
-    'input.js:4: type array found, Array is standard'],
+  }).errors, [
+    'type String found, string is standard',
+    'type array found, Array is standard'],
     'non-canonical');
 
   t.deepEqual(evaluate(function () {
@@ -32,7 +32,7 @@ test('lint', function (t) {
      * @param {string} foo
      */
     return 0;
-  }), [], 'no errors');
+  }).errors, [], 'no errors');
 
   t.end();
 });

--- a/test/lib/nest_params.js
+++ b/test/lib/nest_params.js
@@ -53,6 +53,8 @@ test('nestParams - missing parent', function (t) {
     return 0;
   });
   t.equal(result[0].params.length, 1);
+  t.equal(result[0].errors[0], '@param foo.bar\'s parent foo not found',
+    'correct error message');
   t.equal(result[0].params[0].name, 'foo.bar');
   t.end();
 });

--- a/test/lib/parsers/javascript.js
+++ b/test/lib/parsers/javascript.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tap').test,
-  parse = require('../../lib/parsers/javascript');
+  parse = require('../../../lib/parsers/javascript');
 
 function toComment(fn, filename) {
   return parse({
@@ -23,7 +23,7 @@ test('parse - error', function (t) {
     /** @param {foo */
     return 0;
   })[0].errors, [
-    'test.js:2: Braces are not balanced',
-    'test.js:2: Missing or invalid tag name']);
+    'Braces are not balanced',
+    'Missing or invalid tag name']);
   t.end();
 });

--- a/test/lib/polyglot.js
+++ b/test/lib/polyglot.js
@@ -13,6 +13,7 @@ test('polyglot', function (t) {
   });
   delete result[0].context.file;
   t.deepEqual(result, [{
+    errors: [],
     context: {
       loc: { end: { column: 3, line: 40 }, start: { column: 1, line: 35 } } },
     description: 'This method moves a hex to a color',

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ var UPDATE = !!process.env.UPDATE;
 
 function normalize(result) {
   result.forEach(function (item) {
+    delete item.errors;
     item.context.file = path.relative(__dirname, item.context.file);
   });
   return result;


### PR DESCRIPTION
cc @jfirebaugh @anandthakker for the review

@jfirebaugh re: your comment about functions downstream needing to know about errors that point to invariants... my assumption is that if we hit a showstopper error then we should throw an exception, whereas for 'lint' or handle-able errors we should attach to the comment