### PR TITLE
Walk trailing comments. Fixes #93

### DIFF
--- a/lib/parsers/javascript.js
+++ b/lib/parsers/javascript.js
@@ -86,7 +86,7 @@ module.exports = function (data) {
 
   var visited = {};
 
-  function walkComments(ast, type) {
+  function walkComments(ast, type, includeContext) {
     types.visit(ast, {
       visitNode: function (path) {
         /**
@@ -100,27 +100,33 @@ module.exports = function (data) {
             loc: extend({}, path.value.loc),
             file: data.file
           };
+          // Avoid visiting the same comment twice as a leading
+          // and trailing node
           var key = JSON.stringify(comment.loc);
+          if (!visited[key]) {
+            visited[key] = true;
+            if (includeContext) {
+              // This is non-enumerable so that it doesn't get stringified in
+              // output; e.g. by the documentation binary.
+              Object.defineProperty(context, 'ast', {
+                enumerable: false,
+                value: path
+              });
 
-          if (visited[key]) {
-            return;
+              if (path.parent && path.parent.node) {
+                context.code = code.substring
+                  .apply(code, path.parent.node.range);
+              }
+            } else {
+              // Avoid the invariant of a comment with no AST by providing
+              // an empty one.
+              Object.defineProperty(context, 'ast', {
+                enumerable: false,
+                value: {}
+              });
+            }
+            results.push(parse(comment.value, comment.loc, context));
           }
-
-          visited[key] = true;
-
-          // This is non-enumerable so that it doesn't get stringified in output; e.g. by the
-          // documentation binary.
-          Object.defineProperty(context, 'ast', {
-            enumerable: false,
-            value: path
-          });
-
-          if (path.parent && path.parent.node) {
-            context.code = code.substring
-              .apply(code, path.parent.node.range);
-          }
-
-          results.push(parse(comment.value, comment.loc, context));
         }
 
         (path.value[type] || [])
@@ -132,8 +138,8 @@ module.exports = function (data) {
     });
   }
 
-  walkComments(ast, 'leadingComments');
-  walkComments(ast, 'trailingComments');
+  walkComments(ast, 'leadingComments', true);
+  walkComments(ast, 'trailingComments', false);
 
   return results;
 };

--- a/lib/parsers/javascript.js
+++ b/lib/parsers/javascript.js
@@ -84,42 +84,56 @@ module.exports = function (data) {
   var code = commentShebang(data.source),
     ast = espree.parse(code, espreeConfig);
 
-  types.visit(ast, {
-    visitNode: function (path) {
-      /**
-       * Parse a comment with doctrine and decorate the result with file position and code context.
-       *
-       * @param {Object} comment the current state of the parsed JSDoc comment
-       * @return {undefined} this emits data
-       */
-      function parseComment(comment) {
-        var context = {
-          loc: extend({}, path.value.loc),
-          file: data.file
-        };
+  var visited = {};
 
-        // This is non-enumerable so that it doesn't get stringified in output; e.g. by the
-        // documentation binary.
-        Object.defineProperty(context, 'ast', {
-          enumerable: false,
-          value: path
-        });
+  function walkComments(ast, type) {
+    types.visit(ast, {
+      visitNode: function (path) {
+        /**
+         * Parse a comment with doctrine and decorate the result with file position and code context.
+         *
+         * @param {Object} comment the current state of the parsed JSDoc comment
+         * @return {undefined} this emits data
+         */
+        function parseComment(comment) {
+          var context = {
+            loc: extend({}, path.value.loc),
+            file: data.file
+          };
+          var key = JSON.stringify(comment.loc);
 
-        if (path.parent && path.parent.node) {
-          context.code = code.substring
-            .apply(code, path.parent.node.range);
+          if (visited[key]) {
+            return;
+          }
+
+          visited[key] = true;
+
+          // This is non-enumerable so that it doesn't get stringified in output; e.g. by the
+          // documentation binary.
+          Object.defineProperty(context, 'ast', {
+            enumerable: false,
+            value: path
+          });
+
+          if (path.parent && path.parent.node) {
+            context.code = code.substring
+              .apply(code, path.parent.node.range);
+          }
+
+          results.push(parse(comment.value, comment.loc, context));
         }
 
-        results.push(parse(comment.value, comment.loc, context));
+        (path.value[type] || [])
+          .filter(isJSDocComment)
+          .forEach(parseComment);
+
+        this.traverse(path);
       }
+    });
+  }
 
-      (path.value.leadingComments || [])
-        .filter(isJSDocComment)
-        .forEach(parseComment);
-
-      this.traverse(path);
-    }
-  });
+  walkComments(ast, 'leadingComments');
+  walkComments(ast, 'trailingComments');
 
   return results;
 };

--- a/test/fixture/trailing-only.input.js
+++ b/test/fixture/trailing-only.input.js
@@ -1,0 +1,7 @@
+function fooBaz() {
+  return 2;
+}
+/**
+ * this is a type
+ * @return {number} nothing
+ */

--- a/test/fixture/trailing-only.output.custom.md
+++ b/test/fixture/trailing-only.output.custom.md
@@ -1,0 +1,9 @@
+# 
+
+this is a type
+
+
+Returns **number** nothing
+
+
+

--- a/test/fixture/trailing-only.output.json
+++ b/test/fixture/trailing-only.output.json
@@ -1,0 +1,58 @@
+[
+  {
+    "description": "this is a type",
+    "tags": [
+      {
+        "title": "returns",
+        "description": "nothing",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 4,
+        "column": 0
+      },
+      "end": {
+        "line": 7,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 3,
+          "column": 1
+        }
+      }
+    },
+    "errors": [],
+    "returns": [
+      {
+        "title": "returns",
+        "description": "nothing",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "events": [],
+    "path": [
+      null
+    ]
+  }
+]

--- a/test/fixture/trailing-only.output.md
+++ b/test/fixture/trailing-only.output.md
@@ -1,0 +1,9 @@
+# 
+
+this is a type
+
+
+Returns **number** nothing
+
+
+

--- a/test/fixture/trailing-only.output.md.json
+++ b/test/fixture/trailing-only.output.md.json
@@ -1,0 +1,138 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "this is a type",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 15
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 15
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Returns "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "number"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "root",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "nothing",
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 8
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 1,
+                          "column": 1
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 8
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 8
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixture/trailing.input.js
+++ b/test/fixture/trailing.input.js
@@ -1,0 +1,18 @@
+/**
+ * ONE
+ * @return {number} something
+ */
+function fooBar() {
+  return 1;
+}
+/**
+ * TWO
+ * @return {number} something
+ */
+function fooBaz() {
+  return 2;
+}
+/**
+ * this is a type
+ * @class Something
+ */

--- a/test/fixture/trailing.output.custom.md
+++ b/test/fixture/trailing.output.custom.md
@@ -1,0 +1,25 @@
+# Something
+
+this is a type
+
+
+
+# fooBar
+
+ONE
+
+
+Returns **number** something
+
+
+
+
+# fooBaz
+
+TWO
+
+
+Returns **number** something
+
+
+

--- a/test/fixture/trailing.output.json
+++ b/test/fixture/trailing.output.json
@@ -1,0 +1,169 @@
+[
+  {
+    "description": "this is a type",
+    "tags": [
+      {
+        "title": "class",
+        "description": null,
+        "lineNumber": 2,
+        "type": null,
+        "name": "Something"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 1
+        }
+      },
+      "code": "function fooBar() {\n  return 1;\n}\n/**\n * TWO\n * @return {number} something\n */\nfunction fooBaz() {\n  return 2;\n}"
+    },
+    "errors": [],
+    "class": {
+      "name": "Something"
+    },
+    "name": "Something",
+    "kind": "class",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "events": [],
+    "path": [
+      "Something"
+    ]
+  },
+  {
+    "description": "ONE",
+    "tags": [
+      {
+        "title": "returns",
+        "description": "something",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 4,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 7,
+          "column": 1
+        }
+      },
+      "code": "function fooBar() {\n  return 1;\n}\n/**\n * TWO\n * @return {number} something\n */\nfunction fooBaz() {\n  return 2;\n}"
+    },
+    "errors": [],
+    "returns": [
+      {
+        "title": "returns",
+        "description": "something",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "name": "fooBar",
+    "kind": "function",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "events": [],
+    "path": [
+      "fooBar"
+    ]
+  },
+  {
+    "description": "TWO",
+    "tags": [
+      {
+        "title": "returns",
+        "description": "something",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 8,
+        "column": 0
+      },
+      "end": {
+        "line": 11,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 1
+        }
+      },
+      "code": "function fooBar() {\n  return 1;\n}\n/**\n * TWO\n * @return {number} something\n */\nfunction fooBaz() {\n  return 2;\n}"
+    },
+    "errors": [],
+    "returns": [
+      {
+        "title": "returns",
+        "description": "something",
+        "lineNumber": 2,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "name": "fooBaz",
+    "kind": "function",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "events": [],
+    "path": [
+      "fooBaz"
+    ]
+  }
+]

--- a/test/fixture/trailing.output.json
+++ b/test/fixture/trailing.output.json
@@ -30,8 +30,7 @@
           "line": 14,
           "column": 1
         }
-      },
-      "code": "function fooBar() {\n  return 1;\n}\n/**\n * TWO\n * @return {number} something\n */\nfunction fooBaz() {\n  return 2;\n}"
+      }
     },
     "errors": [],
     "class": {

--- a/test/fixture/trailing.output.md
+++ b/test/fixture/trailing.output.md
@@ -1,0 +1,25 @@
+# Something
+
+this is a type
+
+
+
+# fooBar
+
+ONE
+
+
+Returns **number** something
+
+
+
+
+# fooBaz
+
+TWO
+
+
+Returns **number** something
+
+
+

--- a/test/fixture/trailing.output.md.json
+++ b/test/fixture/trailing.output.md.json
@@ -1,0 +1,334 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text",
+              "value": "Something"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "this is a type",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 15
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 15
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text",
+              "value": "fooBar"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "ONE",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 4
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 4
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 4
+            }
+          }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Returns "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "number"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "root",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "something",
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 10
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 1,
+                          "column": 1
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 10
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 10
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text",
+              "value": "fooBaz"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "TWO",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 4
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 4
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 4
+            }
+          }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Returns "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "number"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "root",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "something",
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 10
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 1,
+                          "column": 1
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 10
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 10
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The reason for the two-separate-walks quirk of this code is that comments are attached as _both_ trailing and leading, and we always want to prefer the leading.

* [x] ensure that trailing commas also never get code attached to them

cc @jfirebaugh for the review