### PR TITLE
Infer parameters. Fixes #51

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var sort = require('./lib/sort'),
   hierarchy = require('./lib/hierarchy'),
   inferName = require('./lib/infer/name'),
   inferKind = require('./lib/infer/kind'),
+  inferParams = require('./lib/infer/params'),
   inferMembership = require('./lib/infer/membership'),
   lint = require('./lib/lint');
 
@@ -59,7 +60,12 @@ module.exports = function (indexes, options, callback) {
         }, [])
         .map(function (comment) {
           // compose nesting & membership to avoid intermediate arrays
-          comment = nestParams(inferMembership(inferKind(inferName(lint(comment)))));
+          comment = nestParams(
+            inferMembership(
+              inferParams(
+                inferKind(
+                  inferName(
+                    lint(comment))))));
           if (options.github) {
             comment = github(comment);
           }

--- a/lib/html_helpers.js
+++ b/lib/html_helpers.js
@@ -88,6 +88,9 @@ function autolink(paths, text) {
  * // generates String
  */
 function formatType(type, paths) {
+  if (!type) {
+    return '';
+  }
   function recurse(element) {
     return formatType(element, paths);
   }

--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -25,11 +25,6 @@ module.exports = function inferParams(comment) {
 
       path.value.params.forEach(function (param) {
         if (existingParams[param.name] === undefined) {
-          comment.tags.push({
-            title: 'param',
-            name: param.name,
-            lineNumber: param.loc.start.line
-          });
           if (!comment.params) {
             comment.params = [];
           }
@@ -45,16 +40,11 @@ module.exports = function inferParams(comment) {
       // Ensure that if params are specified partially or in
       // the wrong order, they'll be output in the order
       // they actually appear in code
-      comment.tags.sort(function (a, b) {
-        if (a.title === 'param' && b.title === 'param') {
+      if (comment.params) {
+        comment.params.sort(function (a, b) {
           return paramOrder.indexOf(a.name) - paramOrder.indexOf(b.name);
-        }
-        return 0;
-      });
-
-      (comment.params || []).sort(function (a, b) {
-        return paramOrder.indexOf(a.name) - paramOrder.indexOf(b.name);
-      });
+        });
+      }
 
       this.abort();
     }

--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -16,9 +16,7 @@ module.exports = function inferParams(comment) {
 
       // Ensure that explicitly specified parameters are not overridden
       // by inferred parameters
-      var existingParams = comment.tags.filter(function (tag) {
-        return tag.title === 'param';
-      }).reduce(function (memo, param) {
+      var existingParams = (comment.params || []).reduce(function (memo, param) {
         memo[param.name] = param;
         return memo;
       }, {});
@@ -32,6 +30,14 @@ module.exports = function inferParams(comment) {
             name: param.name,
             lineNumber: param.loc.start.line
           });
+          if (!comment.params) {
+            comment.params = [];
+          }
+          comment.params.push({
+            title: 'param',
+            name: param.name,
+            lineNumber: param.loc.start.line
+          });
         }
         paramOrder.push(param.name);
       });
@@ -41,10 +47,13 @@ module.exports = function inferParams(comment) {
       // they actually appear in code
       comment.tags.sort(function (a, b) {
         if (a.title === 'param' && b.title === 'param') {
-          return paramOrder.indexOf(a.name) -
-            paramOrder.indexOf(b.name);
+          return paramOrder.indexOf(a.name) - paramOrder.indexOf(b.name);
         }
         return 0;
+      });
+
+      (comment.params || []).sort(function (a, b) {
+        return paramOrder.indexOf(a.name) - paramOrder.indexOf(b.name);
       });
 
       this.abort();

--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var types = require('ast-types');
+
+/**
+ * Infers param tags by reading function parameter names
+ *
+ * @name inferParams
+ * @param {Object} comment parsed comment
+ * @returns {Object} comment with parameters
+ */
+module.exports = function inferParams(comment) {
+
+  types.visit(comment.context.ast, {
+    visitFunction: function (path) {
+
+      // Ensure that explicitly specified parameters are not overridden
+      // by inferred parameters
+      var existingParams = comment.tags.filter(function (tag) {
+        return tag.title === 'param';
+      }).reduce(function (memo, param) {
+        memo[param.name] = param;
+        return memo;
+      }, {});
+
+      var paramOrder = [];
+
+      path.value.params.forEach(function (param) {
+        if (existingParams[param.name] === undefined) {
+          comment.tags.push({
+            title: 'param',
+            name: param.name,
+            lineNumber: param.loc.start.line
+          });
+        }
+        paramOrder.push(param.name);
+      });
+
+      // Ensure that if params are specified partially or in
+      // the wrong order, they'll be output in the order
+      // they actually appear in code
+      comment.tags.sort(function (a, b) {
+        if (a.title === 'param' && b.title === 'param') {
+          return paramOrder.indexOf(a.name) -
+            paramOrder.indexOf(b.name);
+        }
+        return 0;
+      });
+
+      this.abort();
+    }
+  });
+
+  return comment;
+};

--- a/test/fixture/es6.output.custom.md
+++ b/test/fixture/es6.output.custom.md
@@ -3,6 +3,14 @@
 This function returns the number one.
 
 
+**Parameters**
+
+-   `a`  
+
+-   `b`  
+
+
+
 Returns **Number** numberone
 
 

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -10,16 +10,6 @@
           "type": "NameExpression",
           "name": "Number"
         }
-      },
-      {
-        "title": "param",
-        "name": "a",
-        "lineNumber": 5
-      },
-      {
-        "title": "param",
-        "name": "b",
-        "lineNumber": 5
       }
     ],
     "loc": {

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -59,6 +59,18 @@
     ],
     "name": "multiply",
     "kind": "function",
+    "params": [
+      {
+        "title": "param",
+        "name": "a",
+        "lineNumber": 5
+      },
+      {
+        "title": "param",
+        "name": "b",
+        "lineNumber": 5
+      }
+    ],
     "members": {
       "instance": [],
       "static": []

--- a/test/fixture/es6.output.md
+++ b/test/fixture/es6.output.md
@@ -3,6 +3,14 @@
 This function returns the number one.
 
 
+**Parameters**
+
+-   `a`  
+
+-   `b`  
+
+
+
 Returns **Number** numberone
 
 

--- a/test/fixture/es6.output.md.json
+++ b/test/fixture/es6.output.md.json
@@ -64,6 +64,98 @@
           "type": "root",
           "children": [
             {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "a"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "b"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
               "type": "paragraph",
               "children": [
                 {

--- a/test/fixture/factory.output.custom.md
+++ b/test/fixture/factory.output.custom.md
@@ -13,9 +13,21 @@ Returns **area** chart
 
 
 
+**Parameters**
+
+-   `selection`  
+
+
+
 
 # data
 
 Sets the chart data.
+
+
+**Parameters**
+
+-   `_`  
+
 
 

--- a/test/fixture/factory.output.json
+++ b/test/fixture/factory.output.json
@@ -67,6 +67,11 @@
         "lineNumber": 1,
         "type": null,
         "name": "area"
+      },
+      {
+        "title": "param",
+        "name": "selection",
+        "lineNumber": 10
       }
     ],
     "loc": {
@@ -115,6 +120,11 @@
         "description": null,
         "lineNumber": 2,
         "name": null
+      },
+      {
+        "title": "param",
+        "name": "_",
+        "lineNumber": 17
       }
     ],
     "loc": {

--- a/test/fixture/factory.output.json
+++ b/test/fixture/factory.output.json
@@ -67,11 +67,6 @@
         "lineNumber": 1,
         "type": null,
         "name": "area"
-      },
-      {
-        "title": "param",
-        "name": "selection",
-        "lineNumber": 10
       }
     ],
     "loc": {
@@ -127,11 +122,6 @@
         "description": null,
         "lineNumber": 2,
         "name": null
-      },
-      {
-        "title": "param",
-        "name": "_",
-        "lineNumber": 17
       }
     ],
     "loc": {

--- a/test/fixture/factory.output.json
+++ b/test/fixture/factory.output.json
@@ -103,6 +103,13 @@
     },
     "name": "area",
     "kind": "class",
+    "params": [
+      {
+        "title": "param",
+        "name": "selection",
+        "lineNumber": 10
+      }
+    ],
     "members": {
       "instance": [],
       "static": []
@@ -156,6 +163,13 @@
     "function": null,
     "name": "data",
     "kind": "function",
+    "params": [
+      {
+        "title": "param",
+        "name": "_",
+        "lineNumber": 17
+      }
+    ],
     "memberof": "chart",
     "scope": "static",
     "members": {

--- a/test/fixture/factory.output.md
+++ b/test/fixture/factory.output.md
@@ -13,9 +13,21 @@ Returns **area** chart
 
 
 
+**Parameters**
+
+-   `selection`  
+
+
+
 
 # data
 
 Sets the chart data.
+
+
+**Parameters**
+
+-   `_`  
+
 
 

--- a/test/fixture/factory.output.md.json
+++ b/test/fixture/factory.output.md.json
@@ -161,6 +161,62 @@
               "column": 1
             }
           }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "selection"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -222,6 +278,62 @@
               "column": 21
             }
           }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "_"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -1809,10 +1809,19 @@ h4:hover .anchorjs-link {
         <div class='px2'>
 <div class='py1'><section class='py2 clearfix'>
   <h2 id='klass' class='mt0'>
-    Klass<span class='gray'></span>
+    Klass<span class='gray'>(foo)</span>
   </h2>
   <p>Creates a new Klass</p>
 
+    <h4>Parameters</h4>
+    <ul class='suppress-p-margin'>
+        <li> <strong>foo</strong>
+          :
+          <span class='force-inline'>
+            
+          </span>
+        </li>
+    </ul>
       <h4>Static members</h4>
         <div class='collapsible' id='klass/magic-number'>
           <a href='#klass/magic-number'>
@@ -2032,7 +2041,7 @@ the referenced class type</p>
         <div class='collapsible' id='klass/withoptions'>
           <a href='#klass/withoptions'>
             <code>
-              #withOptions<span class='gray'>(options)</span>
+              #withOptions<span class='gray'>(options.foo, options.bar, options)</span>
             </code>
             <span class='force-inline'>
               <p>A function with an options parameter</p>
@@ -2042,24 +2051,30 @@ the referenced class type</p>
           <div class='collapser border px2'>
             <section class='py2 clearfix'>
               <h2 id='klass/withoptions' class='mt0'>
-                withOptions<span class='gray'>(options)</span>
+                withOptions<span class='gray'>(options.foo, options.bar, options)</span>
               </h2>
               <p>A function with an options parameter</p>
             
                 <h4>Parameters</h4>
                 <ul class='suppress-p-margin'>
+                    <li><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code> <strong>options.foo</strong>
+                      :
+                      <span class='force-inline'>
+                        
+                      </span>
+                    </li>
+                    <li><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code> <strong>options.bar</strong>
+                      :
+                      <span class='force-inline'>
+                        
+                      </span>
+                    </li>
                     <li><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></code> <strong>options</strong>
                       :
                       <span class='force-inline'>
                         
                       </span>
                     </li>
-                      <ul>
-                          <li><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code> options.foo
-                            </li>
-                          <li><code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code> options.bar
-                            </li>
-                      </ul>
                 </ul>
             </section>
           </div>

--- a/test/fixture/infer-params.input.js
+++ b/test/fixture/infer-params.input.js
@@ -1,0 +1,9 @@
+/* eslint valid-jsdoc: 0 */
+
+/**
+ * This function returns the number one.
+ * @param {number} b the second param
+ */
+function addThem(a, b, c) {
+  return a + b + c;
+};

--- a/test/fixture/infer-params.output.custom.md
+++ b/test/fixture/infer-params.output.custom.md
@@ -1,0 +1,11 @@
+# addThem
+
+This function returns the number one.
+
+
+**Parameters**
+
+-   `b` **number** the second param
+
+
+

--- a/test/fixture/infer-params.output.custom.md
+++ b/test/fixture/infer-params.output.custom.md
@@ -5,7 +5,11 @@ This function returns the number one.
 
 **Parameters**
 
+-   `a`  
+
 -   `b` **number** the second param
+
+-   `c`  
 
 
 

--- a/test/fixture/infer-params.output.json
+++ b/test/fixture/infer-params.output.json
@@ -3,61 +3,63 @@
     "description": "This function returns the number one.",
     "tags": [
       {
-        "title": "returns",
-        "description": "numberone",
+        "title": "param",
+        "name": "a",
+        "lineNumber": 7
+      },
+      {
+        "title": "param",
+        "description": "the second param",
         "lineNumber": 2,
         "type": {
           "type": "NameExpression",
-          "name": "Number"
-        }
+          "name": "number"
+        },
+        "name": "b"
       },
       {
         "title": "param",
-        "name": "a",
-        "lineNumber": 5
-      },
-      {
-        "title": "param",
-        "name": "b",
-        "lineNumber": 5
+        "name": "c",
+        "lineNumber": 7
       }
     ],
     "loc": {
       "start": {
-        "line": 1,
+        "line": 3,
         "column": 0
       },
       "end": {
-        "line": 4,
+        "line": 6,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 5,
+          "line": 7,
           "column": 0
         },
         "end": {
-          "line": 5,
-          "column": 31
+          "line": 9,
+          "column": 1
         }
       },
-      "code": "var multiply = (a, b) => a * b;\n\nexport default multiply;"
+      "code": "function addThem(a, b, c) {\n  return a + b + c;\n};"
     },
     "errors": [],
-    "returns": [
+    "params": [
       {
-        "title": "returns",
-        "description": "numberone",
+        "title": "param",
+        "description": "the second param",
         "lineNumber": 2,
         "type": {
           "type": "NameExpression",
-          "name": "Number"
-        }
+          "name": "number"
+        },
+        "name": "b"
       }
     ],
-    "name": "multiply",
+    "name": "addThem",
     "kind": "function",
     "members": {
       "instance": [],
@@ -65,7 +67,7 @@
     },
     "events": [],
     "path": [
-      "multiply"
+      "addThem"
     ]
   }
 ]

--- a/test/fixture/infer-params.output.json
+++ b/test/fixture/infer-params.output.json
@@ -50,6 +50,11 @@
     "params": [
       {
         "title": "param",
+        "name": "a",
+        "lineNumber": 7
+      },
+      {
+        "title": "param",
         "description": "the second param",
         "lineNumber": 2,
         "type": {
@@ -57,6 +62,11 @@
           "name": "number"
         },
         "name": "b"
+      },
+      {
+        "title": "param",
+        "name": "c",
+        "lineNumber": 7
       }
     ],
     "name": "addThem",

--- a/test/fixture/infer-params.output.json
+++ b/test/fixture/infer-params.output.json
@@ -4,11 +4,6 @@
     "tags": [
       {
         "title": "param",
-        "name": "a",
-        "lineNumber": 7
-      },
-      {
-        "title": "param",
         "description": "the second param",
         "lineNumber": 2,
         "type": {
@@ -16,11 +11,6 @@
           "name": "number"
         },
         "name": "b"
-      },
-      {
-        "title": "param",
-        "name": "c",
-        "lineNumber": 7
       }
     ],
     "loc": {

--- a/test/fixture/infer-params.output.md
+++ b/test/fixture/infer-params.output.md
@@ -1,0 +1,11 @@
+# addThem
+
+This function returns the number one.
+
+
+**Parameters**
+
+-   `b` **number** the second param
+
+
+

--- a/test/fixture/infer-params.output.md
+++ b/test/fixture/infer-params.output.md
@@ -5,7 +5,11 @@ This function returns the number one.
 
 **Parameters**
 
+-   `a`  
+
 -   `b` **number** the second param
+
+-   `c`  
 
 
 

--- a/test/fixture/infer-params.output.md.json
+++ b/test/fixture/infer-params.output.md.json
@@ -84,6 +84,42 @@
                       "children": [
                         {
                           "type": "inlineCode",
+                          "value": "a"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
                           "value": "b"
                         },
                         {
@@ -146,6 +182,42 @@
                             "end": {
                               "line": 1,
                               "column": 17
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "c"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
                             }
                           }
                         }

--- a/test/fixture/infer-params.output.md.json
+++ b/test/fixture/infer-params.output.md.json
@@ -1,0 +1,163 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text",
+              "value": "addThem"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "This function returns the number one.",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 38
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 38
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 38
+            }
+          }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "b"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "number"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "the second param",
+                                  "position": {
+                                    "start": {
+                                      "line": 1,
+                                      "column": 1
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "column": 17
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 1,
+                                  "column": 1
+                                },
+                                "end": {
+                                  "line": 1,
+                                  "column": 17
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 17
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixture/multisignature.output.custom.md
+++ b/test/fixture/multisignature.output.custom.md
@@ -3,6 +3,12 @@
 Get the time
 
 
+**Parameters**
+
+-   `time`  
+
+
+
 Returns **Date** the current date
 
 

--- a/test/fixture/multisignature.output.json
+++ b/test/fixture/multisignature.output.json
@@ -54,6 +54,13 @@
     ],
     "name": "getTheTime",
     "kind": "function",
+    "params": [
+      {
+        "title": "param",
+        "name": "time",
+        "lineNumber": 13
+      }
+    ],
     "members": {
       "instance": [],
       "static": []

--- a/test/fixture/multisignature.output.json
+++ b/test/fixture/multisignature.output.json
@@ -10,6 +10,11 @@
           "type": "NameExpression",
           "name": "Date"
         }
+      },
+      {
+        "title": "param",
+        "name": "time",
+        "lineNumber": 13
       }
     ],
     "loc": {

--- a/test/fixture/multisignature.output.json
+++ b/test/fixture/multisignature.output.json
@@ -10,11 +10,6 @@
           "type": "NameExpression",
           "name": "Date"
         }
-      },
-      {
-        "title": "param",
-        "name": "time",
-        "lineNumber": 13
       }
     ],
     "loc": {

--- a/test/fixture/multisignature.output.md
+++ b/test/fixture/multisignature.output.md
@@ -3,6 +3,12 @@
 Get the time
 
 
+**Parameters**
+
+-   `time`  
+
+
+
 Returns **Date** the current date
 
 

--- a/test/fixture/multisignature.output.md.json
+++ b/test/fixture/multisignature.output.md.json
@@ -64,6 +64,62 @@
           "type": "root",
           "children": [
             {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "time"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
               "type": "paragraph",
               "children": [
                 {


### PR DESCRIPTION
This uses the AST to add (untyped) params where they aren't explicitly
specified.

Would love to infer types here as well, but espree doesn't support
them yet.

cc @anandthakker / @jfirebaugh for the review