### PR TITLE
Implement flow type inference for params. Refs #122

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var sort = require('./lib/sort'),
   inferKind = require('./lib/infer/kind'),
   inferParams = require('./lib/infer/params'),
   inferMembership = require('./lib/infer/membership'),
+  inferReturn = require('./lib/infer/return'),
   lint = require('./lib/lint');
 
 /**
@@ -62,10 +63,11 @@ module.exports = function (indexes, options, callback) {
           // compose nesting & membership to avoid intermediate arrays
           comment = nestParams(
             inferMembership(
-              inferParams(
-                inferKind(
-                  inferName(
-                    lint(comment))))));
+              inferReturn(
+                inferParams(
+                  inferKind(
+                    inferName(
+                      lint(comment)))))));
           if (options.github) {
             comment = github(comment);
           }

--- a/lib/flow_doctrine.js
+++ b/lib/flow_doctrine.js
@@ -1,0 +1,60 @@
+var namedTypes = {
+  'NumberTypeAnnotation': 'number',
+  'BooleanTypeAnnotation': 'boolean',
+  'StringTypeAnnotation': 'string'
+};
+
+var oneToOne = {
+  'AnyTypeAnnotation': {
+    type: 'AllLiteral'
+  }
+};
+
+function flowDoctrine(type) {
+
+  if (type.type in namedTypes) {
+    return {
+      type: 'NameExpression',
+      name: namedTypes[type.type]
+    };
+  }
+
+  if (type.type in oneToOne) {
+    return oneToOne[type.type];
+  }
+
+  if (type.type === 'NullableTypeAnnotation') {
+    return {
+      type: 'OptionalType',
+      expression: flowDoctrine(type.typeAnnotation)
+    };
+  }
+
+  if (type.type === 'UnionTypeAnnotation') {
+    return {
+      type: 'UnionType',
+      elements: type.types.map(flowDoctrine)
+    };
+  }
+
+  if (type.type === 'GenericTypeAnnotation') {
+
+    if (type.typeParameters) {
+      return {
+        type: 'TypeApplication',
+        expression: {
+          type: 'NameExpression',
+          name: type.id.name
+        },
+        applications: type.typeParameters.params.map(flowDoctrine)
+      };
+    }
+
+    return {
+      type: 'NameExpression',
+      name: type.id.name
+    };
+  }
+}
+
+module.exports = flowDoctrine;

--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var types = require('ast-types');
+var types = require('ast-types'),
+  flowDoctrine = require('../flow_doctrine');
 
 /**
  * Infers param tags by reading function parameter names
@@ -29,11 +30,15 @@ module.exports = function inferParams(comment) {
           if (!comment.params) {
             comment.params = [];
           }
-          comment.params.push({
+          var newParam = {
             title: 'param',
             name: param.name,
             lineNumber: param.loc.start.line
-          });
+          };
+          if (param.typeAnnotation && param.typeAnnotation.typeAnnotation) {
+            newParam.type = flowDoctrine(param.typeAnnotation.typeAnnotation);
+          }
+          comment.params.push(newParam);
         }
         paramOrder[param.name] = i++;
       });

--- a/lib/infer/return.js
+++ b/lib/infer/return.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var types = require('ast-types'),
+  flowDoctrine = require('../flow_doctrine');
+
+/**
+ * Infers returns tags by using Flow return type annotations
+ *
+ * @name inferReturn
+ * @param {Object} comment parsed comment
+ * @returns {Object} comment with return tag inferred
+ */
+module.exports = function inferReturn(comment) {
+
+  types.visit(comment.context.ast, {
+    visitFunction: function (path) {
+
+      if (!comment.returns &&
+        path.value.returnType &&
+        path.value.returnType.typeAnnotation) {
+        comment.returns = [{
+          type: flowDoctrine(path.value.returnType.typeAnnotation)
+        }];
+      }
+
+      this.abort();
+    }
+  });
+
+  return comment;
+};

--- a/test/fixture/flow-types.input.js
+++ b/test/fixture/flow-types.input.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+/**
+ * This function returns the number one.
+ */
+function addThem(a: number, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named) {
+  return a + b + c + d + e;
+};
+
+/* eslint-enable */

--- a/test/fixture/flow-types.input.js
+++ b/test/fixture/flow-types.input.js
@@ -3,7 +3,7 @@
 /**
  * This function returns the number one.
  */
-function addThem(a: number, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named) {
+function addThem(a: number, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named): number {
   return a + b + c + d + e;
 };
 

--- a/test/fixture/flow-types.output.custom.md
+++ b/test/fixture/flow-types.output.custom.md
@@ -19,3 +19,7 @@ This function returns the number one.
 
 
 
+Returns **number** 
+
+
+

--- a/test/fixture/flow-types.output.custom.md
+++ b/test/fixture/flow-types.output.custom.md
@@ -1,0 +1,21 @@
+# addThem
+
+This function returns the number one.
+
+
+**Parameters**
+
+-   `a` **number** 
+
+-   `b` **string** 
+
+-   `c` **[boolean]** 
+
+-   `d` **Array<number>** 
+
+-   `e` **Object** 
+
+-   `f` **Named** 
+
+
+

--- a/test/fixture/flow-types.output.json
+++ b/test/fixture/flow-types.output.json
@@ -1,0 +1,108 @@
+[
+  {
+    "description": "This function returns the number one.",
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 3,
+        "column": 0
+      },
+      "end": {
+        "line": 5,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 6,
+          "column": 0
+        },
+        "end": {
+          "line": 8,
+          "column": 1
+        }
+      },
+      "code": "/* eslint-disable */\n\n/**\n * This function returns the number one.\n */\nfunction addThem(a: number, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named) {\n  return a + b + c + d + e;\n};\n\n/* eslint-enable */\n"
+    },
+    "errors": [],
+    "name": "addThem",
+    "kind": "function",
+    "params": [
+      {
+        "title": "param",
+        "name": "a",
+        "lineNumber": 6,
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      },
+      {
+        "title": "param",
+        "name": "b",
+        "lineNumber": 6,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      },
+      {
+        "title": "param",
+        "name": "c",
+        "lineNumber": 6,
+        "type": {
+          "type": "OptionalType",
+          "expression": {
+            "type": "NameExpression",
+            "name": "boolean"
+          }
+        }
+      },
+      {
+        "title": "param",
+        "name": "d",
+        "lineNumber": 6,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Array"
+          },
+          "applications": [
+            {
+              "type": "NameExpression",
+              "name": "number"
+            }
+          ]
+        }
+      },
+      {
+        "title": "param",
+        "name": "e",
+        "lineNumber": 6,
+        "type": {
+          "type": "NameExpression",
+          "name": "Object"
+        }
+      },
+      {
+        "title": "param",
+        "name": "f",
+        "lineNumber": 6,
+        "type": {
+          "type": "NameExpression",
+          "name": "Named"
+        }
+      }
+    ],
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "events": [],
+    "path": [
+      "addThem"
+    ]
+  }
+]

--- a/test/fixture/flow-types.output.json
+++ b/test/fixture/flow-types.output.json
@@ -23,7 +23,7 @@
           "column": 1
         }
       },
-      "code": "/* eslint-disable */\n\n/**\n * This function returns the number one.\n */\nfunction addThem(a: number, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named) {\n  return a + b + c + d + e;\n};\n\n/* eslint-enable */\n"
+      "code": "/* eslint-disable */\n\n/**\n * This function returns the number one.\n */\nfunction addThem(a: number, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named): number {\n  return a + b + c + d + e;\n};\n\n/* eslint-enable */\n"
     },
     "errors": [],
     "name": "addThem",
@@ -93,6 +93,14 @@
         "type": {
           "type": "NameExpression",
           "name": "Named"
+        }
+      }
+    ],
+    "returns": [
+      {
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
         }
       }
     ],

--- a/test/fixture/flow-types.output.md
+++ b/test/fixture/flow-types.output.md
@@ -19,3 +19,7 @@ This function returns the number one.
 
 
 
+Returns **number** 
+
+
+

--- a/test/fixture/flow-types.output.md
+++ b/test/fixture/flow-types.output.md
@@ -1,0 +1,21 @@
+# addThem
+
+This function returns the number one.
+
+
+**Parameters**
+
+-   `a` **number** 
+
+-   `b` **string** 
+
+-   `c` **[boolean]** 
+
+-   `d` **Array<number>** 
+
+-   `e` **Object** 
+
+-   `f` **Named** 
+
+
+

--- a/test/fixture/flow-types.output.md.json
+++ b/test/fixture/flow-types.output.md.json
@@ -349,6 +349,47 @@
               ]
             }
           ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Returns "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "number"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "root",
+                  "children": [],
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 1
+                    }
+                  }
+                }
+              ]
+            }
+          ]
         }
       ]
     }

--- a/test/fixture/flow-types.output.md.json
+++ b/test/fixture/flow-types.output.md.json
@@ -1,0 +1,356 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text",
+              "value": "addThem"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "This function returns the number one.",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 38
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 38
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 38
+            }
+          }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "a"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "number"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "b"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "string"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "c"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "[boolean]"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "d"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "Array<number>"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "e"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "Object"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "f"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "Named"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/lib/flow_doctrine.js
+++ b/test/lib/flow_doctrine.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var flowDoctrine = require('../../lib/flow_doctrine.js'),
+  parse = require('../../lib/parsers/javascript'),
+  test = require('tap').test;
+
+function toComment(fn, filename) {
+  return parse({
+    file: filename,
+    source: fn instanceof Function ? '(' + fn.toString() + ')' : fn
+  })[0];
+}
+
+/* eslint-disable */
+test('flowDoctrine', function (t) {
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: number) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NameExpression',
+      name: 'number'
+    }, 'number');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: string) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NameExpression',
+      name: 'string'
+    }, 'string');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: any) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'AllLiteral'
+    }, 'all');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: ?number) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'OptionalType',
+      expression: {
+        type: 'NameExpression',
+        name: 'number'
+      }
+    }, 'optional');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: number | string) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'UnionType',
+      elements: [
+        {
+          type: 'NameExpression',
+          name: 'number'
+        },
+        {
+          type: 'NameExpression',
+          name: 'string'
+        }
+      ]
+    }, 'union');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: Object) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NameExpression',
+      name: 'Object'
+    }, 'object');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: Array) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NameExpression',
+      name: 'Array'
+    }, 'array');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: Array<number>) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'TypeApplication',
+      expression: {
+        type: 'NameExpression',
+        name: 'Array'
+      },
+      applications: [{
+        type: 'NameExpression',
+        name: 'number'
+      }]
+    }, 'Array<number>');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: boolean) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NameExpression',
+      name: 'boolean'
+    }, 'boolean');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: undefined) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NameExpression',
+      name: 'undefined'
+    }, 'undefined');
+
+  t.end();
+});
+/* eslint-enable */


### PR DESCRIPTION
cc @thejameskyle

cc @jfirebaugh for the review

`lib/flow_doctrine.js` is where we convert Babel-parsed
Flow annotations into doctrine-style objects so they
can be formatted with all of the existing helpers.

As a tail task to this, we'll want to use flow annotations to infer return types as well.