### PR TITLE
Drop @lends tags during membership inference (fixes #161)

### DIFF
--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -113,11 +113,11 @@ module.exports = function () {
       currentModule = comment;
     }
 
-    if (comment.memberof) {
-      return comment;
+    if (comment.lends) {
+      return;
     }
 
-    if (comment.lends) {
+    if (comment.memberof) {
       return comment;
     }
 

--- a/test/lib/infer/membership.js
+++ b/test/lib/infer/membership.js
@@ -136,12 +136,6 @@ test('inferMembership - explicit', function (t) {
     scope: 'static'
   }, 'lends, static');
 
-  t.end();
-});
-
-
-
-test('inferMembership', function (t) {
   t.deepEqual(_.pick(evaluate(function () {
     lend(/** @lends Foo */{
       /**
@@ -182,7 +176,11 @@ test('inferMembership', function (t) {
     lend(/** @lends Foo */{});
     /** Test */
     return 0;
-  })[0].memberof, undefined, 'inferMembership - lends applies only to following object');
+  })[1].memberof, undefined, 'inferMembership - lends applies only to following object');
+
+  t.equal(evaluate(function () {
+    lend(/** @lends Foo */{});
+  })[0], undefined, 'inferMembership - drops lends');
 
   t.end();
 });


### PR DESCRIPTION
Membership inference used to [drop @lends tags](https://github.com/documentationjs/documentation/blob/b9df26fba8afd494ff1d7449821493babfc0c56a/streams/infer/membership.js#L92-L94) as a side effect. Now they make it through the whole chain and produce output even though they aren't meaningful in that way.

This restores the pre-unstream behavior by allowing function elements in the comment pipeline to return undefined to eliminate that comment from further processing.

:eyes: @tmcw 