### PR TITLE
Stop inferring parameters if fn is within a call.

### DIFF
--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -82,7 +82,12 @@ module.exports = function () {
       return newParam;
     }
 
+    function abort() {
+      return false
+    }
+
     types.visit(comment.context.ast, {
+      visitCallExpression: abort,
       visitFunction: function (path) {
 
         // Ensure that explicitly specified parameters are not overridden

--- a/test/fixture/nearby_params.input.js
+++ b/test/fixture/nearby_params.input.js
@@ -1,0 +1,14 @@
+/** Attempt to establish a cookie-based session in exchange for credentials.
+ *  @function
+ *  @name sessions.create
+ *  @param {object} credentials
+ *  @param {string} credentials.name        Login username. Also accepted as `username` or `email`.
+ *  @param {string} credentials.password    Login password
+ *  @param {function} [callback]            Gets passed `(err, { success:Boolean })`.
+ *  @returns {Promise} promise, to be resolved on success or rejected on failure
+ */
+sessions.addMethod('create', 'POST / form', {
+    // normalize request body params
+    before({ body }) {
+    }
+});

--- a/test/fixture/nearby_params.output.custom.md
+++ b/test/fixture/nearby_params.output.custom.md
@@ -1,0 +1,20 @@
+# sessions.create
+
+Attempt to establish a cookie-based session in exchange for credentials.
+
+
+**Parameters**
+
+-   `credentials` **object** 
+    -   `credentials.name` **string** Login username. Also accepted as `username` or `email`.
+
+    -   `credentials.password` **string** Login password
+
+-   `callback` **[function]** Gets passed `(err, { success:Boolean })`.
+
+
+
+Returns **Promise** promise, to be resolved on success or rejected on failure
+
+
+

--- a/test/fixture/nearby_params.output.json
+++ b/test/fixture/nearby_params.output.json
@@ -1,0 +1,190 @@
+[
+  {
+    "description": "Attempt to establish a cookie-based session in exchange for credentials.",
+    "tags": [
+      {
+        "title": "function",
+        "description": null,
+        "lineNumber": 1,
+        "name": null
+      },
+      {
+        "title": "name",
+        "description": null,
+        "lineNumber": 3,
+        "name": "sessions.create"
+      },
+      {
+        "title": "param",
+        "description": null,
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "object"
+        },
+        "name": "credentials",
+        "properties": [
+          {
+            "title": "param",
+            "description": "Login username. Also accepted as `username` or `email`.",
+            "lineNumber": 5,
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "credentials.name"
+          },
+          {
+            "title": "param",
+            "description": "Login password",
+            "lineNumber": 6,
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "credentials.password"
+          }
+        ]
+      },
+      {
+        "title": "param",
+        "description": "Login username. Also accepted as `username` or `email`.",
+        "lineNumber": 5,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "credentials.name"
+      },
+      {
+        "title": "param",
+        "description": "Login password",
+        "lineNumber": 6,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        },
+        "name": "credentials.password"
+      },
+      {
+        "title": "param",
+        "description": "Gets passed `(err, { success:Boolean })`.",
+        "lineNumber": 7,
+        "type": {
+          "type": "OptionalType",
+          "expression": {
+            "type": "NameExpression",
+            "name": "function"
+          }
+        },
+        "name": "callback"
+      },
+      {
+        "title": "returns",
+        "description": "promise, to be resolved on success or rejected on failure",
+        "lineNumber": 8,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 9,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 10,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 3
+        }
+      },
+      "code": "/** Attempt to establish a cookie-based session in exchange for credentials.\n *  @function\n *  @name sessions.create\n *  @param {object} credentials\n *  @param {string} credentials.name        Login username. Also accepted as `username` or `email`.\n *  @param {string} credentials.password    Login password\n *  @param {function} [callback]            Gets passed `(err, { success:Boolean })`.\n *  @returns {Promise} promise, to be resolved on success or rejected on failure\n */\nsessions.addMethod('create', 'POST / form', {\n    // normalize request body params\n    before({ body }) {\n    }\n});\n"
+    },
+    "errors": [
+      {
+        "message": "type object found, Object is standard",
+        "commentLineNumber": 4
+      }
+    ],
+    "function": null,
+    "name": "sessions.create",
+    "params": [
+      {
+        "title": "param",
+        "description": null,
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "object"
+        },
+        "name": "credentials",
+        "properties": [
+          {
+            "title": "param",
+            "description": "Login username. Also accepted as `username` or `email`.",
+            "lineNumber": 5,
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "credentials.name"
+          },
+          {
+            "title": "param",
+            "description": "Login password",
+            "lineNumber": 6,
+            "type": {
+              "type": "NameExpression",
+              "name": "string"
+            },
+            "name": "credentials.password"
+          }
+        ]
+      },
+      {
+        "title": "param",
+        "description": "Gets passed `(err, { success:Boolean })`.",
+        "lineNumber": 7,
+        "type": {
+          "type": "OptionalType",
+          "expression": {
+            "type": "NameExpression",
+            "name": "function"
+          }
+        },
+        "name": "callback"
+      }
+    ],
+    "returns": [
+      {
+        "title": "returns",
+        "description": "promise, to be resolved on success or rejected on failure",
+        "lineNumber": 8,
+        "type": {
+          "type": "NameExpression",
+          "name": "Promise"
+        }
+      }
+    ],
+    "kind": "function",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      "sessions.create"
+    ]
+  }
+]

--- a/test/fixture/nearby_params.output.md
+++ b/test/fixture/nearby_params.output.md
@@ -1,0 +1,20 @@
+# sessions.create
+
+Attempt to establish a cookie-based session in exchange for credentials.
+
+
+**Parameters**
+
+-   `credentials` **object** 
+    -   `credentials.name` **string** Login username. Also accepted as `username` or `email`.
+
+    -   `credentials.password` **string** Login password
+
+-   `callback` **[function]** Gets passed `(err, { success:Boolean })`.
+
+
+
+Returns **Promise** promise, to be resolved on success or rejected on failure
+
+
+

--- a/test/fixture/nearby_params.output.md.json
+++ b/test/fixture/nearby_params.output.md.json
@@ -1,0 +1,531 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "root",
+      "children": [
+        {
+          "depth": 1,
+          "type": "heading",
+          "children": [
+            {
+              "type": "text",
+              "value": "sessions.create"
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Attempt to establish a cookie-based session in exchange for credentials.",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 73
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1
+                },
+                "end": {
+                  "line": 1,
+                  "column": 73
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 73
+            }
+          }
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Parameters"
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "credentials"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "object"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 1
+                            }
+                          }
+                        },
+                        {
+                          "ordered": false,
+                          "type": "list",
+                          "children": [
+                            {
+                              "type": "listItem",
+                              "children": [
+                                {
+                                  "type": "paragraph",
+                                  "children": [
+                                    {
+                                      "type": "inlineCode",
+                                      "value": "credentials.name"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "value": " "
+                                    },
+                                    {
+                                      "type": "strong",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "value": "string"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "value": " "
+                                    },
+                                    {
+                                      "type": "root",
+                                      "children": [
+                                        {
+                                          "type": "paragraph",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "value": "Login username. Also accepted as ",
+                                              "position": {
+                                                "start": {
+                                                  "line": 1,
+                                                  "column": 1
+                                                },
+                                                "end": {
+                                                  "line": 1,
+                                                  "column": 34
+                                                },
+                                                "indent": []
+                                              }
+                                            },
+                                            {
+                                              "type": "inlineCode",
+                                              "value": "username",
+                                              "position": {
+                                                "start": {
+                                                  "line": 1,
+                                                  "column": 34
+                                                },
+                                                "end": {
+                                                  "line": 1,
+                                                  "column": 44
+                                                },
+                                                "indent": []
+                                              }
+                                            },
+                                            {
+                                              "type": "text",
+                                              "value": " or ",
+                                              "position": {
+                                                "start": {
+                                                  "line": 1,
+                                                  "column": 44
+                                                },
+                                                "end": {
+                                                  "line": 1,
+                                                  "column": 48
+                                                },
+                                                "indent": []
+                                              }
+                                            },
+                                            {
+                                              "type": "inlineCode",
+                                              "value": "email",
+                                              "position": {
+                                                "start": {
+                                                  "line": 1,
+                                                  "column": 48
+                                                },
+                                                "end": {
+                                                  "line": 1,
+                                                  "column": 55
+                                                },
+                                                "indent": []
+                                              }
+                                            },
+                                            {
+                                              "type": "text",
+                                              "value": ".",
+                                              "position": {
+                                                "start": {
+                                                  "line": 1,
+                                                  "column": 55
+                                                },
+                                                "end": {
+                                                  "line": 1,
+                                                  "column": 56
+                                                },
+                                                "indent": []
+                                              }
+                                            }
+                                          ],
+                                          "position": {
+                                            "start": {
+                                              "line": 1,
+                                              "column": 1
+                                            },
+                                            "end": {
+                                              "line": 1,
+                                              "column": 56
+                                            },
+                                            "indent": []
+                                          }
+                                        }
+                                      ],
+                                      "position": {
+                                        "start": {
+                                          "line": 1,
+                                          "column": 1
+                                        },
+                                        "end": {
+                                          "line": 1,
+                                          "column": 56
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "listItem",
+                              "children": [
+                                {
+                                  "type": "paragraph",
+                                  "children": [
+                                    {
+                                      "type": "inlineCode",
+                                      "value": "credentials.password"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "value": " "
+                                    },
+                                    {
+                                      "type": "strong",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "value": "string"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "value": " "
+                                    },
+                                    {
+                                      "type": "root",
+                                      "children": [
+                                        {
+                                          "type": "paragraph",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "value": "Login password",
+                                              "position": {
+                                                "start": {
+                                                  "line": 1,
+                                                  "column": 1
+                                                },
+                                                "end": {
+                                                  "line": 1,
+                                                  "column": 15
+                                                },
+                                                "indent": []
+                                              }
+                                            }
+                                          ],
+                                          "position": {
+                                            "start": {
+                                              "line": 1,
+                                              "column": 1
+                                            },
+                                            "end": {
+                                              "line": 1,
+                                              "column": 15
+                                            },
+                                            "indent": []
+                                          }
+                                        }
+                                      ],
+                                      "position": {
+                                        "start": {
+                                          "line": 1,
+                                          "column": 1
+                                        },
+                                        "end": {
+                                          "line": 1,
+                                          "column": 15
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "callback"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "[function]"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "root",
+                          "children": [
+                            {
+                              "type": "paragraph",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "value": "Gets passed ",
+                                  "position": {
+                                    "start": {
+                                      "line": 1,
+                                      "column": 1
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "column": 13
+                                    },
+                                    "indent": []
+                                  }
+                                },
+                                {
+                                  "type": "inlineCode",
+                                  "value": "(err, { success:Boolean })",
+                                  "position": {
+                                    "start": {
+                                      "line": 1,
+                                      "column": 13
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "column": 41
+                                    },
+                                    "indent": []
+                                  }
+                                },
+                                {
+                                  "type": "text",
+                                  "value": ".",
+                                  "position": {
+                                    "start": {
+                                      "line": 1,
+                                      "column": 41
+                                    },
+                                    "end": {
+                                      "line": 1,
+                                      "column": 42
+                                    },
+                                    "indent": []
+                                  }
+                                }
+                              ],
+                              "position": {
+                                "start": {
+                                  "line": 1,
+                                  "column": 1
+                                },
+                                "end": {
+                                  "line": 1,
+                                  "column": 42
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 42
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Returns "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Promise"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "root",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "promise, to be resolved on success or rejected on failure",
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 58
+                            },
+                            "indent": []
+                          }
+                        }
+                      ],
+                      "position": {
+                        "start": {
+                          "line": 1,
+                          "column": 1
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 58
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 58
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #191

This a specific exception for the case identified in 191: we could,
instead, include only cases of clear proximity, like var foo = function,
or function foo.

cc @developit 