### PR TITLE
Fix default theme resolve

### DIFF
--- a/lib/output/html.js
+++ b/lib/output/html.js
@@ -2,9 +2,9 @@
 
 var File = require('vinyl'),
   vfs = require('vinyl-fs'),
+  extend = require('extend'),
   concat = require('concat-stream'),
   Handlebars = require('handlebars'),
-  extend = require('extend'),
   walk = require('../walk'),
   getTemplate = require('../get_template'),
   resolveTheme = require('../resolve_theme'),
@@ -47,16 +47,12 @@ function highlight(comment) {
  * @name html
  */
 module.exports = function makeHTML(comments, opts, callback) {
-
   comments = walk(comments, highlight);
 
-  var options = extend({}, {
-    theme: 'documentation-theme-default'
-  }, opts);
-
+  var options = extend({}, opts);
   var themeModule = resolveTheme(options.theme);
-
   var pageTemplate = getTemplate(Handlebars, themeModule, 'index.hbs');
+  
   Handlebars.registerPartial('section',
     getTemplate(Handlebars, themeModule, 'section.hbs'));
 
@@ -75,7 +71,7 @@ module.exports = function makeHTML(comments, opts, callback) {
         path: 'index.html',
         contents: new Buffer(pageTemplate({
           docs: comments,
-          options: opts
+          options: options
         }), 'utf8')
       })));
     }));

--- a/lib/resolve_theme.js
+++ b/lib/resolve_theme.js
@@ -6,13 +6,17 @@ var path = require('path'),
 /**
  * Given the name of a theme as a module, return the directory it
  * resides in, or throw an error if it is not found
- * @param {string} theme the module name
+ * @param {string} [theme='documentation-theme-default'] the module name
  * @throws {Error} if theme is not found
  * @returns {string} directory
  */
 function resolveTheme(theme) {
+  var basedir = theme ? process.cwd() : __dirname;
+  
+  theme = theme || 'documentation-theme-default';
+
   try {
-    return path.dirname(resolve.sync(theme, { basedir: process.cwd() }));
+    return path.dirname(resolve.sync(theme, { basedir: basedir }));
   } catch (e) {
     throw new Error('Theme ' + theme + ' not found');
   }


### PR DESCRIPTION
Basically the default theme is in the documentation modules node_modules and `resolve` doesn't seem to traverse down and find all of the node_modules directories of all the dependencies, so we have to treat the default as a special case.

Not sure if this is the best way, but it works. Willing to change if there are better options.

Resolves #146 