### PR TITLE
Fix exception when formatting string errors

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -36,7 +36,7 @@ function parseJSDoc(comment, loc, context) {
     var tag = result.tags[i];
     if (tag.errors) {
       for (var j = 0; j < tag.errors.length; j++) {
-        result.errors.push(tag.errors[j]);
+        result.errors.push({message: tag.errors[j]});
       }
       result.tags.splice(i, 1);
     } else {

--- a/test/lib/lint.js
+++ b/test/lib/lint.js
@@ -2,7 +2,8 @@
 
 var test = require('tap').test,
   parse = require('../../lib/parsers/javascript'),
-  lint = require('../../lib/lint').lint;
+  lint = require('../../lib/lint').lint,
+  format = require('../../lib/lint').format;
 
 function toComment(fn, filename) {
   return parse({
@@ -20,8 +21,11 @@ test('lint', function (t) {
     /**
      * @param {String} foo
      * @param {array} bar
+     * @param {foo
      */
   }).errors, [
+    { message: 'Braces are not balanced' },
+    { message: 'Missing or invalid tag name' },
     { commentLineNumber: 1, message: 'type String found, string is standard' },
     { commentLineNumber: 2, message: 'type array found, Array is standard' }],
     'non-canonical');
@@ -37,6 +41,27 @@ test('lint', function (t) {
      * @param {string} foo
      */
   }).errors, [], 'no errors');
+
+  t.end();
+});
+
+test('format', function (t) {
+  var comment = evaluate(function () {
+    /**
+     * @param {String} foo
+     * @param {array} bar
+     * @param {foo
+     */
+  });
+
+  var formatted = format([comment]);
+
+  t.contains(formatted, 'input.js');
+  t.contains(formatted, /1:1[^\n]+Braces are not balanced/);
+  t.contains(formatted, /1:1[^\n]+Missing or invalid tag name/);
+  t.contains(formatted, /3:1[^\n]+type String found, string is standard/);
+  t.contains(formatted, /4:1[^\n]+type array found, Array is standard/);
+  t.contains(formatted, '4 warnings');
 
   t.end();
 });

--- a/test/lib/parsers/javascript.js
+++ b/test/lib/parsers/javascript.js
@@ -21,7 +21,7 @@ test('parse - error', function (t) {
   t.deepEqual(toComment(function () {
     /** @param {foo */
   })[0].errors, [
-    'Braces are not balanced',
-    'Missing or invalid tag name']);
+    { message: 'Braces are not balanced' },
+    { message: 'Missing or invalid tag name' }]);
   t.end();
 });


### PR DESCRIPTION
Not all errors are `{message: ...}` objects, [some are plain strings](https://github.com/documentationjs/documentation/compare/lint-format?expand=1#diff-c720f471f49a4909dad9b9fda144eed4L24). 

Fortunately, `vFile#warn` [handles this case for us](https://github.com/wooorm/vfile/blob/master/index.js#L421).

This PR ensures that `format` doesn't throw a runtime exception when passed such an error. 

cc @jfirebaugh @tmcw 