### PR TITLE
Add an extension option

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function (indexes, options, callback) {
           (options.private || options.lint) ? [] : undefined,
           hierarchy(
             inputs
-              .filter(filterJS)
+              .filter(filterJS(options.extension))
               .reduce(function (memo, file) {
                 return memo.concat(parseFn(file));
               }, [])

--- a/lib/args.js
+++ b/lib/args.js
@@ -56,9 +56,8 @@ function parse(args) {
   })
 
   .option('extension', {
-    describe: 'only input source files matching this extension will be parsed.' +
+    describe: 'only input source files matching this extension will be parsed, ' +
       'this option can be used multiple times.',
-    default: 'js',
     alias: 'e'
   })
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -55,6 +55,13 @@ function parse(args) {
     default: 'stdout'
   })
 
+  .option('extension', {
+    describe: 'only input source files matching this extension will be parsed.' +
+      'this option can be used multiple times.',
+    default: 'js',
+    alias: 'e'
+  })
+
   .describe('c', 'configuration file. an array defining explicit sort order')
   .alias('c', 'config')
 
@@ -117,7 +124,8 @@ module.exports = function (args) {
       github: argv.github,
       polyglot: argv.polyglot,
       order: config.order || [],
-      shallow: argv.shallow
+      shallow: argv.shallow,
+      extension: argv.extension
     },
     formatter: argv.f,
     formatterOptions: {

--- a/lib/filter_js.js
+++ b/lib/filter_js.js
@@ -3,14 +3,30 @@
 /**
  * Node & browserify support requiring JSON files. JSON files can't be documented
  * with JSDoc or parsed with espree, so we filter them out before
- * they reach documentation's machinery.
+ * they reach documentation's machinery. 
+ * This creates a filter function for use with Array.prototype.filter, which
+ * expect as argument a file as an objectg with the 'file' property
  *
  * @public
- * @param {Object} data a file as an object with 'file' property
- * @return {boolean} whether the file is json
+ * @param {String|Array} extensions to be filtered
+ * @return {Function}
  */
-function filterJS(data) {
-  return !data.file.match(/\.json$/);
+function filterJS(extensions) {
+  if (typeof extensions === 'string') {
+    extensions = [extensions];
+  }
+
+  return function(data) {
+    var extension;
+    for (var i = 0; i < extensions.length; i++) {
+      extension = extensions[i];
+      if (data.file.slice(-(extension.length + 1)) === '.' + extension) {
+        return true;
+      }
+    }
+
+    return false;
+  };
 }
 
 module.exports = filterJS;

--- a/lib/filter_js.js
+++ b/lib/filter_js.js
@@ -13,9 +13,11 @@
  * is in the extension whitelist
  */
 function filterJS(extensions) {
-  if (typeof extensions === 'string') {
-    extensions = [extensions];
+  if (!(extensions instanceof Array)) {
+    extensions = typeof extensions === 'string' ? [extensions] : [];
   }
+
+  extensions.push('js');
 
   return function (data) {
     var extension;

--- a/lib/filter_js.js
+++ b/lib/filter_js.js
@@ -9,14 +9,15 @@
  *
  * @public
  * @param {String|Array} extensions to be filtered
- * @return {Function}
+ * @return {Function} a filter function, this function returns true if the input filename extension
+ * is in the extension whitelist
  */
 function filterJS(extensions) {
   if (typeof extensions === 'string') {
     extensions = [extensions];
   }
 
-  return function(data) {
+  return function (data) {
     var extension;
     for (var i = 0; i < extensions.length; i++) {
       extension = extensions[i];


### PR DESCRIPTION
Adding a new extension option would change the current behavior of parsing every input files from module-deps except json ones. But if one use browserify to require json files he may also require other file types (JSON is not the only case, as many transform exist for various file types) that can't be supported by documentationjs.

The new behaviour would be to parse files whose extensions match one in a whitelist (the "extension option")