### PR TITLE
optional language detection in examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,12 +79,16 @@ function expandInputs(indexes, options, callback) {
  * even in JavaScript code. With the polyglot option set, this has no effect.
  * @param {Array<string|Object>} [options.order=[]] optional array that
  * defines sorting order of documentation
+ * @param {Object} [options.hljs] hljs optional options
+ * @param {boolean} [options.hljs.highlightAuto=false] hljs automatically detect language
+ * @param {Array} [options.hljs.languages] languages for hljs to choose from
  * @param {Function} callback to be called when the documentation generation
  * is complete, with (err, result) argumentsj
  * @returns {undefined} calls callback
  */
 module.exports = function (indexes, options, callback) {
   options = options || {};
+  options.hljs = options.hljs || {};
 
   if (typeof indexes === 'string') {
     indexes = [indexes];

--- a/lib/args.js
+++ b/lib/args.js
@@ -168,7 +168,8 @@ module.exports = function (args) {
     formatterOptions: {
       name: name,
       version: version,
-      theme: argv.theme
+      theme: argv.theme,
+      hljs: config.hljs || {}
     },
     output: argv.o
   }

--- a/lib/output/html.js
+++ b/lib/output/html.js
@@ -18,7 +18,19 @@ var File = require('vinyl'),
  * @returns {string} highlighted html
  */
 function highlightString(example) {
-  return hljs.highlight('js', example).value;
+  var highlighted = hljs.highlight('js', example);
+  return highlighted.value;
+}
+
+/**
+ * Given a string of Text, return a string of HTML representing
+ * that code snippet highlighted. Let highlight.js guess the language
+ * @param {string} example string of javascript
+ * @returns {string} highlighted html
+ */
+function highlightAutoString(example) {
+  var highlighted = hljs.highlightAuto(example);
+  return highlighted.value;
 }
 
 /**
@@ -26,10 +38,18 @@ function highlightString(example) {
  *
  * @name highlight
  * @param {Object} comment parsed comment
+ * @param {Object} [options] options
  * @return {Object} comment with highlighted code
  */
-function highlight(comment) {
-  if (comment.examples) {
+function highlight(comment, options) {
+  var hljsOptions = (options || {}).hljs || {},
+    autoHighlight = hljsOptions.highlightAuto && comment.examples;
+
+  hljs.configure(hljsOptions);
+
+  if (autoHighlight) {
+    comment.examples = comment.examples.map(highlightAutoString);
+  } else if (comment.examples) {
     comment.examples = comment.examples.map(highlightString);
   }
   return comment;
@@ -46,9 +66,8 @@ function highlight(comment) {
  * @name html
  */
 module.exports = function makeHTML(comments, options, callback) {
-  comments = walk(comments, highlight);
-
   options = options || {};
+  comments = walk(comments, highlight, options);
 
   var themeModule = resolveTheme(options.theme);
   var pageTemplate = getTemplate(Handlebars, themeModule, 'index.hbs');

--- a/lib/output/markdown_ast.js
+++ b/lib/output/markdown_ast.js
@@ -1,7 +1,8 @@
 var mdast = require('mdast'),
   u = require('unist-builder'),
   formatType = require('../markdown_format_type'),
-  formatInlineTags = require('../format_inline_tags');
+  formatInlineTags = require('../format_inline_tags'),
+  hljs = require('highlight.js');
 
 /**
  * Given a hierarchy-nested set of comments, generate an mdast-compatible
@@ -13,6 +14,10 @@ var mdast = require('mdast'),
  * @returns {undefined} calls callback
  */
 function commentsToAST(comments, opts, callback) {
+  var hljsOptions = (opts || {}).hljs || {},
+    language = !hljsOptions.highlightAuto ? 'javascript' : undefined;
+
+  hljs.configure(hljsOptions);
 
   /**
    * Generate an AST chunk for a comment at a given depth: this is
@@ -79,7 +84,8 @@ function commentsToAST(comments, opts, callback) {
     function examplesSection(comment) {
       return !!comment.examples && [u('strong', [u('text', 'Examples')])]
         .concat(comment.examples.map(function (example) {
-          return u('code', { lang: 'javascript' }, example);
+          language = hljsOptions.highlightAuto ? hljs.highlightAuto(example).language : 'javascript';
+          return u('code', { lang: language }, example);
         }));
     }
 

--- a/lib/walk.js
+++ b/lib/walk.js
@@ -4,11 +4,12 @@
  *
  * @param {Array<Object>} comments an array of nested comments
  * @param {Function} fn a walker function
+ * @param {Object} [options] options passed through to walker function
  * @returns {Array<Object>} comments
  */
-function walk(comments, fn) {
+function walk(comments, fn, options) {
   comments.forEach(function (comment) {
-    fn(comment);
+    fn(comment, options);
     for (var scope in comment.members) {
       walk(comment.members[scope], fn);
     }

--- a/test/bin.js
+++ b/test/bin.js
@@ -207,6 +207,27 @@ test('write to html', function (t) {
     }, false);
 }, options);
 
+test('write to html, highlightAuto', function (t) {
+
+  var fixture = 'fixture/auto_lang_hljs/multilanguage.input.js',
+    config = 'fixture/auto_lang_hljs/config.yml',
+    dstDir = path.join(os.tmpdir(), (Date.now() + Math.random()).toString());
+
+  fs.mkdirSync(dstDir);
+
+  documentation(['build --shallow ' + fixture + ' -c ' + config + ' -f html -o ' + dstDir], {},
+    function (err) {
+      var result = fs.readFileSync(path.join(dstDir, 'index.html'), 'utf8');
+      t.ok(result.indexOf('<span class="hljs-number">42</span>') > 0,
+        'javascript is recognized by highlightjs');
+      t.ok(result.indexOf('<span class="hljs-attr_selector">[data-foo]</span>') > 0,
+        'css is recognized by highlightjs');
+      t.ok(result.indexOf('<span class="hljs-attribute">data-foo</span>') > 0,
+        'html is recognized by highlightjs');
+      t.end();
+    }, false);
+}, options);
+
 test('fatal error', function (t) {
 
   documentation(['build --shallow fixture/bad/syntax.input.js'], {},

--- a/test/fixture/auto_lang_hljs/config.yml
+++ b/test/fixture/auto_lang_hljs/config.yml
@@ -1,0 +1,6 @@
+hljs:
+  highlightAuto: true
+  languages:
+    - js
+    - css
+    - html

--- a/test/fixture/auto_lang_hljs/multilanguage.input.js
+++ b/test/fixture/auto_lang_hljs/multilanguage.input.js
@@ -1,0 +1,21 @@
+/**
+ * This function returns the number one.
+ * @returns {Number} numberone
+ * @example
+ * var myFoo = new Foo('[data-foo]');
+ * myFoo.foo(42);
+ * @example
+ * <p data-foo>Data-Foo Element in the dom</p>
+ * @example
+ * [data-foo] {
+ *    background-color: red;
+ * }
+ * @throws {Error} if you give it something
+ * @throws {TypeError} if you give it something else
+ * @augments Foo
+ * @augments Bar
+ */
+module.exports = function () {
+  // this returns 1
+  return 1;
+};

--- a/test/fixture/auto_lang_hljs/multilanguage.output.md
+++ b/test/fixture/auto_lang_hljs/multilanguage.output.md
@@ -1,0 +1,22 @@
+# multilanguage.input
+
+This function returns the number one.
+
+**Examples**
+
+```js
+var myFoo = new Foo('[data-foo]');
+myFoo.foo(42);
+```
+
+```html
+<p data-foo>Data-Foo Element in the dom</p>
+```
+
+```css
+[data-foo] {
+   background-color: red;
+}
+```
+
+Returns **Number** numberone

--- a/test/test.js
+++ b/test/test.js
@@ -187,6 +187,25 @@ test('markdown', function (tt) {
   tt.end();
 });
 
+test('highlightAuto md output', function (t) {
+  var file = path.join(__dirname, 'fixture/auto_lang_hljs/multilanguage.input.js'),
+    hljsConfig = {hljs: {highlightAuto: true, languages: ['js', 'css', 'html']}};
+
+  documentation(file, null, function (err, result) {
+    t.ifError(err);
+    outputMarkdown(result, hljsConfig, function (err, result) {
+      t.ifError(err);
+      var outputfile = file.replace('.input.js', '.output.md');
+      if (UPDATE) {
+        fs.writeFileSync(outputfile, result, 'utf8');
+      }
+      var expect = fs.readFileSync(outputfile, 'utf8');
+      t.equal(result.toString(), expect, 'recognizes examples in html, css and js');
+      t.end();
+    });
+  });
+});
+
 test('multi-file input', function (t) {
   documentation([
     path.join(__dirname, 'fixture', 'simple.input.js'),


### PR DESCRIPTION
This is opt-in, hence not a breaking change: make highlightjs recognizing the language of `@example` code snippets.

Please review – your feedback is highly appreciated :smiley: 