### PR TITLE
add an external option

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -55,6 +55,12 @@ function parse(args) {
     default: 'stdout'
   })
 
+  .option('external', {
+    describe: 'a string / glob match pattern that defines which external ' +
+      'modules will be whitelisted and included in the generated documentation.',
+    default: null
+  })
+
   .describe('c', 'configuration file. an array defining explicit sort order')
   .alias('c', 'config')
 
@@ -117,6 +123,7 @@ module.exports = function (args) {
       github: argv.github,
       polyglot: argv.polyglot,
       order: config.order || [],
+      external: argv.external,
       shallow: argv.shallow
     },
     formatter: argv.f,

--- a/lib/module_filters.js
+++ b/lib/module_filters.js
@@ -26,7 +26,6 @@ module.exports = {
   externals: function externalModuleFilter(indexes, options) {
     var externalFilters = false;
     if (options.external) {
-      var test = micromatch.matcher(options.external);
       externalFilters = indexes.map(function (index) {
         // grab the path of the top-level node_modules directory.
         var topNodeModules = path.join(path.dirname(index), 'node_modules');
@@ -45,7 +44,7 @@ module.exports = {
           }
           // test the path relative to the top node_modules dir.
           var p = path.relative(topNodeModules, file);
-          return test(p);
+          return micromatch.any(p, options.external);
         };
       });
     }


### PR DESCRIPTION
add an external option for the cli and permit the use of multiple patterns / globs
in an array. Use micromatch.any() instead of micromatch.matcher()