### PR TITLE
Add an extension option

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function (indexes, options, callback) {
           options.private ? [] : undefined,
           hierarchy(
             inputs
-              .filter(filterJS)
+              .filter(filterJS(options.extension))
               .reduce(function (memo, file) {
                 return memo.concat(parseFn(file));
               }, [])

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports.lint = function lint(indexes, options, callback) {
     callback(null,
       formatLint(hierarchy(
         inputs
-          .filter(filterJS)
+          .filter(filterJS(options.extension))
           .reduce(function (memo, file) {
             return memo.concat(parseFn(file));
           }, [])

--- a/lib/args.js
+++ b/lib/args.js
@@ -18,6 +18,11 @@ function commonOptions(parser) {
       'modules will be whitelisted and included in the generated documentation.',
     default: null
   })
+  .option('extension', {
+    describe: 'only input source files matching this extension will be parsed, ' +
+      'this option can be used multiple times.',
+    alias: 'e'
+  })
   .option('polyglot', {
     type: 'boolean',
     describe: 'polyglot mode turns off dependency resolution and ' +
@@ -155,7 +160,8 @@ module.exports = function (args) {
       polyglot: argv.polyglot,
       order: config.order || [],
       external: argv.external,
-      shallow: argv.shallow
+      shallow: argv.shallow,
+      extension: argv.extension
     },
     formatter: argv.format,
     watch: argv.w,

--- a/lib/filter_js.js
+++ b/lib/filter_js.js
@@ -1,9 +1,11 @@
 'use strict';
 
+var path = require('path');
+
 /**
  * Node & browserify support requiring JSON files. JSON files can't be documented
  * with JSDoc or parsed with espree, so we filter them out before
- * they reach documentation's machinery. 
+ * they reach documentation's machinery.
  * This creates a filter function for use with Array.prototype.filter, which
  * expect as argument a file as an objectg with the 'file' property
  *
@@ -13,22 +15,15 @@
  * is in the extension whitelist
  */
 function filterJS(extensions) {
-  if (!(extensions instanceof Array)) {
-    extensions = typeof extensions === 'string' ? [extensions] : [];
-  }
 
-  extensions.push('js');
+  extensions = extensions || [];
+  if (typeof extensions === 'string') {
+    extensions = [extensions];
+  }
+  extensions = extensions.concat('js');
 
   return function (data) {
-    var extension;
-    for (var i = 0; i < extensions.length; i++) {
-      extension = extensions[i];
-      if (data.file.slice(-(extension.length + 1)) === '.' + extension) {
-        return true;
-      }
-    }
-
-    return false;
+    return extensions.indexOf(path.extname(data.file).substring(1)) !== -1;
   };
 }
 

--- a/lib/filter_js.js
+++ b/lib/filter_js.js
@@ -3,14 +3,33 @@
 /**
  * Node & browserify support requiring JSON files. JSON files can't be documented
  * with JSDoc or parsed with espree, so we filter them out before
- * they reach documentation's machinery.
+ * they reach documentation's machinery. 
+ * This creates a filter function for use with Array.prototype.filter, which
+ * expect as argument a file as an objectg with the 'file' property
  *
  * @public
- * @param {Object} data a file as an object with 'file' property
- * @return {boolean} whether the file is json
+ * @param {String|Array} extensions to be filtered
+ * @return {Function} a filter function, this function returns true if the input filename extension
+ * is in the extension whitelist
  */
-function filterJS(data) {
-  return !data.file.match(/\.json$/);
+function filterJS(extensions) {
+  if (!(extensions instanceof Array)) {
+    extensions = typeof extensions === 'string' ? [extensions] : [];
+  }
+
+  extensions.push('js');
+
+  return function (data) {
+    var extension;
+    for (var i = 0; i < extensions.length; i++) {
+      extension = extensions[i];
+      if (data.file.slice(-(extension.length + 1)) === '.' + extension) {
+        return true;
+      }
+    }
+
+    return false;
+  };
 }
 
 module.exports = filterJS;

--- a/test/bin.js
+++ b/test/bin.js
@@ -96,6 +96,15 @@ test('external modules option', function (t) {
   });
 });
 
+test('extension option', function (t) {
+  documentation(['build fixture/extension/jsx.jsx ' +
+    '--extension=jsx'], function (err, data) {
+    t.ifError(err);
+    t.equal(data.length, 1, 'includes jsx file');
+    t.end();
+  });
+});
+
 test('invalid arguments', function (group) {
   group.test('bad -f option', function (t) {
     documentation(['build -f DOES-NOT-EXIST fixture/internal.input.js'], function (err) {

--- a/test/fixture/extension/jsx.jsx
+++ b/test/fixture/extension/jsx.jsx
@@ -1,0 +1,4 @@
+/**
+ * apples
+ */
+function apples() {}


### PR DESCRIPTION
This new option change the previous behavior of parsing every input files
from module-deps except json. But if one use browserify to require json file
they may require other file types that cant be supported by documentationjs,
the new behaviour is to parse files whose extension match one in a whitelist

This is a rebased version of #242