### PR TITLE
Support new node versions, including v4 and v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # documentation
 
-[![Build Status](https://circleci.com/gh/documentationjs/documentation.svg?style=svg)](https://circleci.com/gh/documentationjs/documentation) [![Coverage Status](https://coveralls.io/repos/documentationjs/documentation/badge.svg?branch=master)](https://coveralls.io/r/documentationjs/documentation?branch=master)
+[![Circle CI](https://circleci.com/gh/documentationjs/documentation/tree/master.svg?style=svg)](https://circleci.com/gh/documentationjs/documentation/tree/master)
+[![Coverage Status](https://coveralls.io/repos/documentationjs/documentation/badge.svg?branch=master)](https://coveralls.io/r/documentationjs/documentation?branch=master)
 [![npm version](https://badge.fury.io/js/documentation.svg)](http://badge.fury.io/js/documentation)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/documentationjs/documentation?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  node:
+    version: 0.10.33
+
+dependencies:
+  override:
+    - 'nvm install 5 && nvm use 5 && npm update -g npm'
+    - 'nvm install 0.10 && nvm use 0.10 && npm update -g npm'
+
+test:
+  override:
+    - 'nvm use 5 && rm -rf node_modules && npm install && npm test'
+    - 'nvm use 0.10 && rm -rf node_modules && npm install && npm test'

--- a/docs/NODE_API.md
+++ b/docs/NODE_API.md
@@ -93,10 +93,6 @@ comments, given a root file as a path.
     -   `options.external` **Array&lt;string&gt;** a string regex / glob match pattern
         that defines what external modules will be whitelisted and included in the
         generated documentation.
-
-    -   `options.transform` **Array&lt;string&gt;** source transforms given as strings
-        passed to [the module-deps transform option](https://github.com/substack/module-deps)
-
     -   `options.polyglot` **[boolean]** parse comments with a regex rather than
         a proper parser. This enables support of non-JavaScript languages but
         reduces documentation's ability to infer structure of code.

--- a/index.js
+++ b/index.js
@@ -62,8 +62,6 @@ function expandInputs(indexes, options, callback) {
  * @param {Array<string>} options.external a string regex / glob match pattern
  * that defines what external modules will be whitelisted and included in the
  * generated documentation.
- * @param {Array<string>} options.transform source transforms given as strings
- * passed to [the module-deps transform option](https://github.com/substack/module-deps)
  * @param {boolean} [options.polyglot=false] parse comments with a regex rather than
  * a proper parser. This enables support of non-JavaScript languages but
  * reduces documentation's ability to infer structure of code.
@@ -130,8 +128,6 @@ module.exports = function (indexes, options, callback) {
  * @param {Array<string>} options.external a string regex / glob match pattern
  * that defines what external modules will be whitelisted and included in the
  * generated documentation.
- * @param {Array<string>} options.transform source transforms given as strings
- * passed to [the module-deps transform option](https://github.com/substack/module-deps)
  * @param {boolean} [options.polyglot=false] parse comments with a regex rather than
  * a proper parser. This enables support of non-JavaScript languages but
  * reduces documentation's ability to infer structure of code.

--- a/lib/args.js
+++ b/lib/args.js
@@ -117,8 +117,7 @@ module.exports = function (args) {
     command = argv._[0],
     inputs = argv._.slice(1),
     name = argv.name,
-    version = argv['project-version'],
-    transform;
+    version = argv['project-version'];
 
   if (inputs.length == 0) {
     try {
@@ -126,9 +125,6 @@ module.exports = function (args) {
       inputs = [p.main || 'index.js'];
       name = name || p.name;
       version = version || p.version;
-      if (p.browserify && p.browserify.transform) {
-        transform = p.browserify.transform;
-      }
     } catch (e) {
       yargs.showHelp();
       throw new Error('documentation was given no files and was not run in a module directory');
@@ -155,7 +151,6 @@ module.exports = function (args) {
     command: command,
     options: {
       private: argv.private,
-      transform: transform,
       github: argv.github,
       polyglot: argv.polyglot,
       order: config.order || [],

--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -63,7 +63,7 @@ module.exports = function () {
       var newParam = {
         title: 'param',
         name: param.argument.name,
-        lineNumber: param.loc.start.name,
+        lineNumber: param.loc.start.line,
         type: {
           type: 'RestType'
         }

--- a/lib/sort.js
+++ b/lib/sort.js
@@ -45,5 +45,5 @@ module.exports = function sortDocs(order, a, b) {
     return 1;
   }
 
-  return a.localeCompare(b);
+  return a.toLowerCase().localeCompare(b.toLowerCase());
 };

--- a/package.json
+++ b/package.json
@@ -6,20 +6,11 @@
   "bin": {
     "documentation": "./bin/documentation.js"
   },
-  "browserify": {
-    "transform": [
-      "brfs"
-    ]
-  },
-  "browser": {
-    "vinyl-fs": false
-  },
   "dependencies": {
     "ansi-html": "0.0.5",
     "ast-types": "^0.8.12",
     "babel-core": "^5.0.0",
     "babelify": "^6.3.0",
-    "brfs": "^1.4.0",
     "chokidar": "^1.2.0",
     "concat-stream": "^1.5.0",
     "debounce": "^1.0.0",
@@ -47,7 +38,6 @@
     "stream-array": "^1.1.0",
     "strip-json-comments": "^1.0.2",
     "tiny-lr": "^0.2.1",
-    "traverse": "^0.6.6",
     "unist-builder": "^1.0.0",
     "vfile": "^1.1.2",
     "vfile-reporter": "^1.4.1",
@@ -61,7 +51,7 @@
     "eslint": "^1.5.1",
     "glob": "^5.0.2",
     "lodash": "^3.10.1",
-    "mock-fs": "^3.2.0",
+    "mock-fs": "^3.5.0",
     "tap": "^2.2.0"
   },
   "keywords": [

--- a/test/fixture/es6-import.output.json
+++ b/test/fixture/es6-import.output.json
@@ -329,6 +329,7 @@
       {
         "title": "param",
         "name": "someParams",
+        "lineNumber": 43,
         "type": {
           "type": "RestType"
         }
@@ -375,6 +376,7 @@
       {
         "title": "param",
         "name": "someParams",
+        "lineNumber": 49,
         "type": {
           "type": "RestType",
           "expression": {

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -329,6 +329,7 @@
       {
         "title": "param",
         "name": "someParams",
+        "lineNumber": 43,
         "type": {
           "type": "RestType"
         }
@@ -375,6 +376,7 @@
       {
         "title": "param",
         "name": "someParams",
+        "lineNumber": 49,
         "type": {
           "type": "RestType",
           "expression": {

--- a/test/fixture/flow-types.output.custom.md
+++ b/test/fixture/flow-types.output.custom.md
@@ -1,3 +1,18 @@
+# addThem
+
+This function returns the number one.
+
+**Parameters**
+
+-   `a` **Point** 
+-   `b` **string** 
+-   `c` **[boolean]** 
+-   `d` **Array&lt;number&gt;** 
+-   `e` **Object** 
+-   `f` **Named** 
+
+Returns **number** 
+
 # Point
 
 A 2D point.
@@ -24,21 +39,6 @@ A type with entirely derived properties
 
 -   `x` **number** 
 -   `y` **number** 
-
-# addThem
-
-This function returns the number one.
-
-**Parameters**
-
--   `a` **Point** 
--   `b` **string** 
--   `c` **[boolean]** 
--   `d` **Array&lt;number&gt;** 
--   `e` **Object** 
--   `f` **Named** 
-
-Returns **number** 
 
 # veryImportantTransform
 

--- a/test/fixture/flow-types.output.json
+++ b/test/fixture/flow-types.output.json
@@ -1,5 +1,118 @@
 [
   {
+    "description": "This function returns the number one.",
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 6,
+          "column": 1
+        }
+      },
+      "code": "/**\n * This function returns the number one.\n */\nfunction addThem(a: Point, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named): number {\n  return a + b + c + d + e;\n}\n\n/**\n * A 2D point.\n *\n * @property {number} x this is a prop\n */\ntype Point = {\n  x: number,\n  y: number,\n  rgb: {\n    hex: string\n  },\n  props: {\n    radius: {\n      x: number\n    }\n  }\n};\n\n/**\n * A type with entirely derived properties\n */\ntype Two = {\n  x: number,\n  y: number\n};\n\n/**\n * Just an alias for an array of strings\n */\ntype T = Array<string>;\n\n/**\n * Very Important Transform\n */\nfunction veryImportantTransform(\n  input: Array<string>,\n  options: Object = {}\n): string {\n  return \"42\";\n}\n"
+    },
+    "errors": [],
+    "name": "addThem",
+    "kind": "function",
+    "params": [
+      {
+        "title": "param",
+        "name": "a",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "Point"
+        }
+      },
+      {
+        "title": "param",
+        "name": "b",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "string"
+        }
+      },
+      {
+        "title": "param",
+        "name": "c",
+        "lineNumber": 4,
+        "type": {
+          "type": "OptionalType",
+          "expression": {
+            "type": "NameExpression",
+            "name": "boolean"
+          }
+        }
+      },
+      {
+        "title": "param",
+        "name": "d",
+        "lineNumber": 4,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Array"
+          },
+          "applications": [
+            {
+              "type": "NameExpression",
+              "name": "number"
+            }
+          ]
+        }
+      },
+      {
+        "title": "param",
+        "name": "e",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "Object"
+        }
+      },
+      {
+        "title": "param",
+        "name": "f",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "Named"
+        }
+      }
+    ],
+    "returns": [
+      {
+        "type": {
+          "type": "NameExpression",
+          "name": "number"
+        }
+      }
+    ],
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      "addThem"
+    ]
+  },
+  {
     "description": "A 2D point.",
     "tags": [
       {
@@ -211,119 +324,6 @@
     },
     "path": [
       "Two"
-    ]
-  },
-  {
-    "description": "This function returns the number one.",
-    "tags": [],
-    "loc": {
-      "start": {
-        "line": 1,
-        "column": 0
-      },
-      "end": {
-        "line": 3,
-        "column": 3
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 4,
-          "column": 0
-        },
-        "end": {
-          "line": 6,
-          "column": 1
-        }
-      },
-      "code": "/**\n * This function returns the number one.\n */\nfunction addThem(a: Point, b: string, c: ?boolean, d: Array<number>, e: Object, f: Named): number {\n  return a + b + c + d + e;\n}\n\n/**\n * A 2D point.\n *\n * @property {number} x this is a prop\n */\ntype Point = {\n  x: number,\n  y: number,\n  rgb: {\n    hex: string\n  },\n  props: {\n    radius: {\n      x: number\n    }\n  }\n};\n\n/**\n * A type with entirely derived properties\n */\ntype Two = {\n  x: number,\n  y: number\n};\n\n/**\n * Just an alias for an array of strings\n */\ntype T = Array<string>;\n\n/**\n * Very Important Transform\n */\nfunction veryImportantTransform(\n  input: Array<string>,\n  options: Object = {}\n): string {\n  return \"42\";\n}\n"
-    },
-    "errors": [],
-    "name": "addThem",
-    "kind": "function",
-    "params": [
-      {
-        "title": "param",
-        "name": "a",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "Point"
-        }
-      },
-      {
-        "title": "param",
-        "name": "b",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "string"
-        }
-      },
-      {
-        "title": "param",
-        "name": "c",
-        "lineNumber": 4,
-        "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "boolean"
-          }
-        }
-      },
-      {
-        "title": "param",
-        "name": "d",
-        "lineNumber": 4,
-        "type": {
-          "type": "TypeApplication",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Array"
-          },
-          "applications": [
-            {
-              "type": "NameExpression",
-              "name": "number"
-            }
-          ]
-        }
-      },
-      {
-        "title": "param",
-        "name": "e",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "Object"
-        }
-      },
-      {
-        "title": "param",
-        "name": "f",
-        "lineNumber": 4,
-        "type": {
-          "type": "NameExpression",
-          "name": "Named"
-        }
-      }
-    ],
-    "returns": [
-      {
-        "type": {
-          "type": "NameExpression",
-          "name": "number"
-        }
-      }
-    ],
-    "members": {
-      "instance": [],
-      "static": []
-    },
-    "path": [
-      "addThem"
     ]
   },
   {

--- a/test/fixture/flow-types.output.md
+++ b/test/fixture/flow-types.output.md
@@ -1,3 +1,18 @@
+# addThem
+
+This function returns the number one.
+
+**Parameters**
+
+-   `a` **Point** 
+-   `b` **string** 
+-   `c` **[boolean]** 
+-   `d` **Array&lt;number&gt;** 
+-   `e` **Object** 
+-   `f` **Named** 
+
+Returns **number** 
+
 # Point
 
 A 2D point.
@@ -24,21 +39,6 @@ A type with entirely derived properties
 
 -   `x` **number** 
 -   `y` **number** 
-
-# addThem
-
-This function returns the number one.
-
-**Parameters**
-
--   `a` **Point** 
--   `b` **string** 
--   `c` **[boolean]** 
--   `d` **Array&lt;number&gt;** 
--   `e` **Object** 
--   `f` **Named** 
-
-Returns **number** 
 
 # veryImportantTransform
 

--- a/test/fixture/flow-types.output.md.json
+++ b/test/fixture/flow-types.output.md.json
@@ -7,6 +7,270 @@
       "children": [
         {
           "type": "text",
+          "value": "addThem"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This function returns the number one.",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 38
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 38
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "strong",
+      "children": [
+        {
+          "type": "text",
+          "value": "Parameters"
+        }
+      ]
+    },
+    {
+      "ordered": false,
+      "type": "list",
+      "children": [
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "a"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Point"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "b"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "string"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "c"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "[boolean]"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "d"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Array&lt;number&gt;"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "e"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Object"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "f"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "Named"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Returns "
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
           "value": "Point"
         }
       ]
@@ -479,270 +743,6 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "depth": 1,
-      "type": "heading",
-      "children": [
-        {
-          "type": "text",
-          "value": "addThem"
-        }
-      ]
-    },
-    {
-      "type": "paragraph",
-      "children": [
-        {
-          "type": "text",
-          "value": "This function returns the number one.",
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 38
-            },
-            "indent": []
-          }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1
-        },
-        "end": {
-          "line": 1,
-          "column": 38
-        },
-        "indent": []
-      }
-    },
-    {
-      "type": "strong",
-      "children": [
-        {
-          "type": "text",
-          "value": "Parameters"
-        }
-      ]
-    },
-    {
-      "ordered": false,
-      "type": "list",
-      "children": [
-        {
-          "type": "listItem",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "inlineCode",
-                  "value": "a"
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                },
-                {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "Point"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "listItem",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "inlineCode",
-                  "value": "b"
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                },
-                {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "string"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "listItem",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "inlineCode",
-                  "value": "c"
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                },
-                {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "[boolean]"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "listItem",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "inlineCode",
-                  "value": "d"
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                },
-                {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "Array&lt;number&gt;"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "listItem",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "inlineCode",
-                  "value": "e"
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                },
-                {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "Object"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "listItem",
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "inlineCode",
-                  "value": "f"
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                },
-                {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "Named"
-                    }
-                  ]
-                },
-                {
-                  "type": "text",
-                  "value": " "
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "type": "paragraph",
-      "children": [
-        {
-          "type": "text",
-          "value": "Returns "
-        },
-        {
-          "type": "strong",
-          "children": [
-            {
-              "type": "text",
-              "value": "number"
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "value": " "
         }
       ]
     },

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -1334,15 +1334,25 @@ h4:hover .anchorjs-link {
             type='text' />
           <div id='toc'>
               <a
+                href='#bar'
+                class='block bold'>
+                bar
+              </a>
+              <a
+                href='#bar'
+                class='block bold'>
+                bar
+              </a>
+              <a
+                href='#bar'
+                class='block bold'>
+                bar
+              </a>
+              <a
                 href='#Klass'
                 class='block bold'>
                 Klass
               </a>
-                <a
-                  href='#Klass.MAGIC_NUMBER'
-                  class='regular block'>
-                  .MAGIC_NUMBER
-                </a>
                 <a
                   href='#Klass.event'
                   class='regular block'>
@@ -1369,6 +1379,11 @@ h4:hover .anchorjs-link {
                   .isWeird
                 </a>
                 <a
+                  href='#Klass.MAGIC_NUMBER'
+                  class='regular block'>
+                  .MAGIC_NUMBER
+                </a>
+                <a
                   href='#Klass.getFoo'
                   class='regular block'>
                   #getFoo
@@ -1378,27 +1393,67 @@ h4:hover .anchorjs-link {
                   class='regular block'>
                   #withOptions
                 </a>
-              <a
-                href='#bar'
-                class='block bold'>
-                bar
-              </a>
-              <a
-                href='#bar'
-                class='block bold'>
-                bar
-              </a>
-              <a
-                href='#bar'
-                class='block bold'>
-                bar
-              </a>
           </div>
         </div>
       </div>
       <div class='fix-margin-3'>
         <div class='px2'>
 <div class='py1'><section class='py2 clearfix'>
+  <h2 id='bar' class='mt0'>
+    bar<span class='gray'></span>
+  </h2>
+  <p>Get an instance of <a href="Klass"><code>Klass</code></a>. Will make
+a <a href="Klass"><code>klass instance multiword</code></a>,
+like a <a href="Klass"><code>klass</code></a></p>
+
+      <h4>Returns</h4>
+      <code>undefined</code>
+      :
+      <div class='force-inline'>
+        <p>nothing</p>
+
+      </div>
+</section>
+</div><div class='py1'><section class='py2 clearfix'>
+  <h2 id='bar' class='mt0'>
+    bar<span class='gray'>(toys)</span>
+  </h2>
+  <p>Rest property function</p>
+
+    <h4>Parameters</h4>
+    <ul class='suppress-p-margin'>
+        <li>...<code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code> <strong>toys</strong>
+          :
+          <div class='force-inline'>
+            
+          </div>
+        </li>
+    </ul>
+      <h4>Returns</h4>
+      <code>undefined</code>
+      :
+      <div class='force-inline'>
+        <p>nothing</p>
+
+      </div>
+</section>
+</div><div class='py1'><section class='py2 clearfix'>
+  <h2 id='bar' class='mt0'>
+    bar<span class='gray'></span>
+  </h2>
+  <p>Get an instance of <a href="Klass"><code>Klass</code></a>. Will make
+a <a href="Klass"><code>klass instance multiword</code></a>,
+like a <a href="Klass"><code>klass</code></a></p>
+
+      <h4>Returns</h4>
+      <code><code><a href="#Klass">Klass</a></code></code>
+      :
+      <div class='force-inline'>
+        <p>that class</p>
+
+      </div>
+</section>
+</div><div class='py1'><section class='py2 clearfix'>
   <h2 id='Klass' class='mt0'>
     Klass<span class='gray'>(foo)</span>
   </h2>
@@ -1414,26 +1469,6 @@ h4:hover .anchorjs-link {
         </li>
     </ul>
       <h4>Static members</h4>
-        <div class='collapsible' id='Klass.MAGIC_NUMBER'>
-          <a href='#Klass.MAGIC_NUMBER'>
-            <code>
-              .MAGIC_NUMBER<span class='gray'></span>
-            </code>
-            <div class='force-inline'>
-              <p>A magic number that identifies this Klass.</p>
-
-            </div>
-          </a>
-          <div class='collapser border px2 m2'>
-            <section class='py2 clearfix'>
-              <h2 id='Klass.MAGIC_NUMBER' class='mt0'>
-                MAGIC_NUMBER<span class='gray'></span>
-              </h2>
-              <p>A magic number that identifies this Klass.</p>
-            
-            </section>
-          </div>
-        </div>
         <div class='collapsible' id='Klass.event'>
           <a href='#Klass.event'>
             <code>
@@ -1619,6 +1654,26 @@ the referenced class type</p>
             </section>
           </div>
         </div>
+        <div class='collapsible' id='Klass.MAGIC_NUMBER'>
+          <a href='#Klass.MAGIC_NUMBER'>
+            <code>
+              .MAGIC_NUMBER<span class='gray'></span>
+            </code>
+            <div class='force-inline'>
+              <p>A magic number that identifies this Klass.</p>
+
+            </div>
+          </a>
+          <div class='collapser border px2 m2'>
+            <section class='py2 clearfix'>
+              <h2 id='Klass.MAGIC_NUMBER' class='mt0'>
+                MAGIC_NUMBER<span class='gray'></span>
+              </h2>
+              <p>A magic number that identifies this Klass.</p>
+            
+            </section>
+          </div>
+        </div>
       <h4>Instance members</h4>
         <div class='collapsible' id='Klass.getFoo'>
           <a href='#Klass.getFoo'>
@@ -1690,61 +1745,6 @@ the referenced class type</p>
             </section>
           </div>
         </div>
-</section>
-</div><div class='py1'><section class='py2 clearfix'>
-  <h2 id='bar' class='mt0'>
-    bar<span class='gray'></span>
-  </h2>
-  <p>Get an instance of <a href="Klass"><code>Klass</code></a>. Will make
-a <a href="Klass"><code>klass instance multiword</code></a>,
-like a <a href="Klass"><code>klass</code></a></p>
-
-      <h4>Returns</h4>
-      <code>undefined</code>
-      :
-      <div class='force-inline'>
-        <p>nothing</p>
-
-      </div>
-</section>
-</div><div class='py1'><section class='py2 clearfix'>
-  <h2 id='bar' class='mt0'>
-    bar<span class='gray'>(toys)</span>
-  </h2>
-  <p>Rest property function</p>
-
-    <h4>Parameters</h4>
-    <ul class='suppress-p-margin'>
-        <li>...<code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code> <strong>toys</strong>
-          :
-          <div class='force-inline'>
-            
-          </div>
-        </li>
-    </ul>
-      <h4>Returns</h4>
-      <code>undefined</code>
-      :
-      <div class='force-inline'>
-        <p>nothing</p>
-
-      </div>
-</section>
-</div><div class='py1'><section class='py2 clearfix'>
-  <h2 id='bar' class='mt0'>
-    bar<span class='gray'></span>
-  </h2>
-  <p>Get an instance of <a href="Klass"><code>Klass</code></a>. Will make
-a <a href="Klass"><code>klass instance multiword</code></a>,
-like a <a href="Klass"><code>klass</code></a></p>
-
-      <h4>Returns</h4>
-      <code><code><a href="#Klass">Klass</a></code></code>
-      :
-      <div class='force-inline'>
-        <p>that class</p>
-
-      </div>
 </section>
 </div>
         </div>

--- a/test/fixture/nearby_params.output.json
+++ b/test/fixture/nearby_params.output.json
@@ -11,13 +11,13 @@
       {
         "title": "name",
         "description": null,
-        "lineNumber": 3,
+        "lineNumber": 2,
         "name": "sessions.create"
       },
       {
         "title": "param",
         "description": null,
-        "lineNumber": 4,
+        "lineNumber": 3,
         "type": {
           "type": "NameExpression",
           "name": "object"
@@ -27,7 +27,7 @@
           {
             "title": "param",
             "description": "Login username. Also accepted as `username` or `email`.",
-            "lineNumber": 5,
+            "lineNumber": 4,
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -37,7 +37,7 @@
           {
             "title": "param",
             "description": "Login password",
-            "lineNumber": 6,
+            "lineNumber": 5,
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -49,7 +49,7 @@
       {
         "title": "param",
         "description": "Login username. Also accepted as `username` or `email`.",
-        "lineNumber": 5,
+        "lineNumber": 4,
         "type": {
           "type": "NameExpression",
           "name": "string"
@@ -59,7 +59,7 @@
       {
         "title": "param",
         "description": "Login password",
-        "lineNumber": 6,
+        "lineNumber": 5,
         "type": {
           "type": "NameExpression",
           "name": "string"
@@ -69,7 +69,7 @@
       {
         "title": "param",
         "description": "Gets passed `(err, { success:Boolean })`.",
-        "lineNumber": 7,
+        "lineNumber": 6,
         "type": {
           "type": "OptionalType",
           "expression": {
@@ -82,7 +82,7 @@
       {
         "title": "returns",
         "description": "promise, to be resolved on success or rejected on failure",
-        "lineNumber": 8,
+        "lineNumber": 7,
         "type": {
           "type": "NameExpression",
           "name": "Promise"
@@ -119,7 +119,7 @@
       {
         "title": "param",
         "description": null,
-        "lineNumber": 4,
+        "lineNumber": 3,
         "type": {
           "type": "NameExpression",
           "name": "object"
@@ -129,7 +129,7 @@
           {
             "title": "param",
             "description": "Login username. Also accepted as `username` or `email`.",
-            "lineNumber": 5,
+            "lineNumber": 4,
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -139,7 +139,7 @@
           {
             "title": "param",
             "description": "Login password",
-            "lineNumber": 6,
+            "lineNumber": 5,
             "type": {
               "type": "NameExpression",
               "name": "string"
@@ -151,7 +151,7 @@
       {
         "title": "param",
         "description": "Gets passed `(err, { success:Boolean })`.",
-        "lineNumber": 7,
+        "lineNumber": 6,
         "type": {
           "type": "OptionalType",
           "expression": {
@@ -166,7 +166,7 @@
       {
         "title": "returns",
         "description": "promise, to be resolved on success or rejected on failure",
-        "lineNumber": 8,
+        "lineNumber": 7,
         "type": {
           "type": "NameExpression",
           "name": "Promise"

--- a/test/fixture/trailing.output.custom.md
+++ b/test/fixture/trailing.output.custom.md
@@ -1,7 +1,3 @@
-# Something
-
-this is a type
-
 # fooBar
 
 ONE
@@ -13,3 +9,7 @@ Returns **number** something
 TWO
 
 Returns **number** something
+
+# Something
+
+this is a type

--- a/test/fixture/trailing.output.json
+++ b/test/fixture/trailing.output.json
@@ -1,52 +1,5 @@
 [
   {
-    "description": "this is a type",
-    "tags": [
-      {
-        "title": "class",
-        "description": null,
-        "lineNumber": 2,
-        "type": null,
-        "name": "Something"
-      }
-    ],
-    "loc": {
-      "start": {
-        "line": 15,
-        "column": 0
-      },
-      "end": {
-        "line": 18,
-        "column": 3
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 12,
-          "column": 0
-        },
-        "end": {
-          "line": 14,
-          "column": 1
-        }
-      }
-    },
-    "errors": [],
-    "class": {
-      "name": "Something"
-    },
-    "name": "Something",
-    "kind": "class",
-    "members": {
-      "instance": [],
-      "static": []
-    },
-    "path": [
-      "Something"
-    ]
-  },
-  {
     "description": "ONE",
     "tags": [
       {
@@ -160,6 +113,53 @@
     },
     "path": [
       "fooBaz"
+    ]
+  },
+  {
+    "description": "this is a type",
+    "tags": [
+      {
+        "title": "class",
+        "description": null,
+        "lineNumber": 2,
+        "type": null,
+        "name": "Something"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 15,
+        "column": 0
+      },
+      "end": {
+        "line": 18,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 12,
+          "column": 0
+        },
+        "end": {
+          "line": 14,
+          "column": 1
+        }
+      }
+    },
+    "errors": [],
+    "class": {
+      "name": "Something"
+    },
+    "name": "Something",
+    "kind": "class",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      "Something"
     ]
   }
 ]

--- a/test/fixture/trailing.output.md
+++ b/test/fixture/trailing.output.md
@@ -1,7 +1,3 @@
-# Something
-
-this is a type
-
 # fooBar
 
 ONE
@@ -13,3 +9,7 @@ Returns **number** something
 TWO
 
 Returns **number** something
+
+# Something
+
+this is a type

--- a/test/fixture/trailing.output.md.json
+++ b/test/fixture/trailing.output.md.json
@@ -7,47 +7,6 @@
       "children": [
         {
           "type": "text",
-          "value": "Something"
-        }
-      ]
-    },
-    {
-      "type": "paragraph",
-      "children": [
-        {
-          "type": "text",
-          "value": "this is a type",
-          "position": {
-            "start": {
-              "line": 1,
-              "column": 1
-            },
-            "end": {
-              "line": 1,
-              "column": 15
-            },
-            "indent": []
-          }
-        }
-      ],
-      "position": {
-        "start": {
-          "line": 1,
-          "column": 1
-        },
-        "end": {
-          "line": 1,
-          "column": 15
-        },
-        "indent": []
-      }
-    },
-    {
-      "depth": 1,
-      "type": "heading",
-      "children": [
-        {
-          "type": "text",
           "value": "fooBar"
         }
       ]
@@ -229,6 +188,47 @@
           }
         }
       ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "Something"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "this is a type",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 15
+        },
+        "indent": []
+      }
     }
   ]
 }


### PR DESCRIPTION
This upstream issue is quite a doozy: https://github.com/nodejs/node/issues/4067

Possibly the only way to get around this would be to not test sorting functions in v0.10 and v0.12