### PR TITLE
In HTML output, also generate `index.json`.

### DIFF
--- a/lib/output/html.js
+++ b/lib/output/html.js
@@ -75,12 +75,18 @@ module.exports = function makeHTML(comments, options, callback) {
   // push assets into the pipeline as well.
   vfs.src([themeModule + '/assets/**'], { base: themeModule })
     .pipe(concat(function (files) {
-      callback(null, files.concat(new File({
-        path: 'index.html',
-        contents: new Buffer(pageTemplate({
-          docs: comments,
-          options: options
-        }), 'utf8')
-      })));
+      callback(null, files.concat([
+        new File({
+          path: 'index.html',
+          contents: new Buffer(pageTemplate({
+            docs: comments,
+            options: options
+          }), 'utf8')
+        }),
+        new File({
+          path: 'index.json',
+          contents: new Buffer(JSON.stringify(comments, null, 2))
+        })
+      ]));
     }));
 };


### PR DESCRIPTION
Minor addition to the HTML output format to include an "index.json" file with the JSON output.  Reason:
 - Make the world a better place by just including the machine-readable form by default.
 - Convenient when developing both documentationjs itself and themes (especially after generalizing the theme interface to just be a `json => vinyl` function)

cc @tmcw @jfirebaugh 