### PR TITLE
Add support for Flow literal string/number types

### DIFF
--- a/lib/flow_doctrine.js
+++ b/lib/flow_doctrine.js
@@ -11,6 +11,11 @@ var oneToOne = {
   }
 };
 
+var literalTypes = {
+  'StringLiteralTypeAnnotation': 'StringLiteral',
+  'NumberLiteralTypeAnnotation': 'NumberLiteral'
+};
+
 function flowDoctrine(type) {
 
   if (type.type in namedTypes) {
@@ -54,6 +59,13 @@ function flowDoctrine(type) {
     return {
       type: 'NameExpression',
       name: type.id.name
+    };
+  }
+
+  if (type.type in literalTypes) {
+    return {
+      type: literalTypes[type.type],
+      name: type.value
     };
   }
 }

--- a/test/lib/flow_doctrine.js
+++ b/test/lib/flow_doctrine.js
@@ -112,6 +112,22 @@ test('flowDoctrine', function (t) {
       name: 'undefined'
     }, 'undefined');
 
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: \"value\") { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'StringLiteral',
+      name: 'value'
+    }, 'StringLiteral');
+
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: 1) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'NumberLiteral',
+      name: '1'
+    }, 'NumberLiteral');
+
   t.end();
 });
 /* eslint-enable */


### PR DESCRIPTION
This PR adds support for string and number literal types from flow. 

Consider this example:
```js
var x: "a";
```

the relevant ast tree from flow for this would be:
```json
"typeAnnotation":{
    "type":"StringLiteralTypeAnnotation",
    "loc": {},
    "range": {},
    "value":"a",
    "raw":"\"a\""
}
```

The same also works with numbers.

