### PR TITLE
Add support for flow boolean literal type

### DIFF
--- a/lib/flow_doctrine.js
+++ b/lib/flow_doctrine.js
@@ -13,7 +13,8 @@ var oneToOne = {
 
 var literalTypes = {
   'StringLiteralTypeAnnotation': 'StringLiteral',
-  'NumberLiteralTypeAnnotation': 'NumberLiteral'
+  'NumberLiteralTypeAnnotation': 'NumberLiteral',
+  'BooleanLiteralTypeAnnotation': 'BooleanLiteral'
 };
 
 function flowDoctrine(type) {

--- a/test/lib/flow_doctrine.js
+++ b/test/lib/flow_doctrine.js
@@ -128,6 +128,14 @@ test('flowDoctrine', function (t) {
       name: '1'
     }, 'NumberLiteral');
 
+  t.deepEqual(flowDoctrine(toComment(
+      "/** add */function add(a: true) { }"
+    ).context.ast.value.params[0].typeAnnotation.typeAnnotation),
+    {
+      type: 'BooleanLiteral',
+      name: true
+    }, 'BooleanLiteral');
+
   t.end();
 });
 /* eslint-enable */


### PR DESCRIPTION
In my last PR #325 I forgot that there also might be boolean literal types.

These are now added. Sorry for the confusion.