### PR TITLE
Remove ast-types dependency

### DIFF
--- a/lib/infer/finders.js
+++ b/lib/infer/finders.js
@@ -1,4 +1,4 @@
-var n = require('ast-types').namedTypes;
+var t = require('babel-types');
 
 function findTarget(path) {
 
@@ -11,28 +11,22 @@ function findTarget(path) {
   }
 
   // var x = TARGET;
-  if (n.VariableDeclaration.check(path)) {
+  if (t.isVariableDeclaration(path)) {
     return path.declarations[0].init;
   }
 
   // foo.x = TARGET
-  if (n.ExpressionStatement.check(path)) {
+  if (t.isExpressionStatement(path)) {
     return path.expression.right;
   }
 
   return path;
 }
 
-function findType(node, type) {
-  var target = findTarget(node);
-  return n[type].check(target) && target;
-}
-
 function findClass(node) {
   var target = findTarget(node);
-  return (n.ClassDeclaration.check(target) || n.ClassExpression.check(target)) && target;
+  return (t.isClassDeclaration(target) || t.isClassExpression(target)) && target;
 }
 
 module.exports.findTarget = findTarget;
-module.exports.findType = findType;
 module.exports.findClass = findClass;

--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var shouldSkipInference = require('./should_skip_inference'),
+  t = require('babel-types'),
   finders = require('./finders'),
   flowDoctrine = require('../flow_doctrine');
 
@@ -142,9 +143,9 @@ function paramToDoc(param, comment, i, prefix) {
  */
 module.exports = function () {
   return shouldSkipInference(function inferParams(comment) {
-    var node = finders.findType(comment.context.ast, 'Function');
+    var node = finders.findTarget(comment.context.ast);
 
-    if (!node) {
+    if (!t.isFunction(node)) {
       return comment;
     }
 

--- a/lib/infer/properties.js
+++ b/lib/infer/properties.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var shouldSkipInference = require('./should_skip_inference'),
-  finders = require('./finders'),
+  t = require('babel-types'),
   flowDoctrine = require('../flow_doctrine');
 
 
@@ -58,10 +58,8 @@ module.exports = function () {
       }
     }
 
-    var node = finders.findType(comment.context.ast, 'TypeAlias');
-
-    if (node) {
-      inferProperties(node.right, []);
+    if (t.isTypeAlias(comment.context.ast)) {
+      inferProperties(comment.context.ast.node.right, []);
     }
 
     return comment;

--- a/lib/infer/return.js
+++ b/lib/infer/return.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var finders = require('./finders'),
+  t = require('babel-types'),
   shouldSkipInference = require('./should_skip_inference'),
   flowDoctrine = require('../flow_doctrine');
 
@@ -16,8 +17,9 @@ module.exports = function () {
     if (comment.returns) {
       return comment;
     }
-    var fn = finders.findType(comment.context.ast, 'Function');
-    if (fn.returnType &&
+    var fn = finders.findTarget(comment.context.ast);
+    if (t.isFunction(fn) &&
+      fn.returnType &&
       fn.returnType.typeAnnotation) {
       comment.returns = [{
         type: flowDoctrine(fn.returnType.typeAnnotation)

--- a/lib/is_jsdoc_comment.js
+++ b/lib/is_jsdoc_comment.js
@@ -9,7 +9,7 @@
  * comments.
  *
  * @name isJSDocComment
- * @param {Object} comment an ast-types node of the comment
+ * @param {Object} comment an ast node of the comment
  * @return {boolean} whether it is valid
  */
 module.exports = function isJSDocComment(comment) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "ansi-html": "0.0.5",
-    "ast-types": "^0.8.12",
     "babel-core": "^6.5.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",


### PR DESCRIPTION
ast-types has been superseded by babel-types in this codebase.