### PR TITLE
support github enterprise url

### DIFF
--- a/lib/git/url_prefix.js
+++ b/lib/git/url_prefix.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var urlFromGit = require('github-url-from-git');
+var gitUrlParse = require('git-url-parse');
 var getRemoteOrigin = require('remote-origin-url');
 
 /**
@@ -20,7 +20,7 @@ function getGithubURLPrefix(root) {
     } else {
       sha = head;
     }
-    return urlFromGit(getRemoteOrigin.sync(root)) + '/blob/' + sha.trim() + '/';
+    return gitUrlParse(getRemoteOrigin.sync(root)).toString('https') + '/blob/' + sha.trim() + '/';
   } catch (e) {
     return null;
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "events": "^1.1.0",
     "extend": "^3.0.0",
     "get-comments": "^1.0.1",
-    "github-url-from-git": "^1.4.0",
+    "git-url-parse": "^6.0.1",
     "highlight.js": "^9.1.0",
     "js-yaml": "^3.3.1",
     "jsdoc-inline-lex": "^1.0.1",

--- a/test/lib/git/mock_repo.js
+++ b/test/lib/git/mock_repo.js
@@ -43,5 +43,25 @@ module.exports = {
         }
       }
     }
+  },
+  enterprise: {
+    '/my': {
+      repository: {
+        path: {
+          '.git': {
+            'HEAD': 'ref: refs/heads/master',
+            'config': '[remote "origin"]\n' +
+              'url = git@github.enterprise.com:foo/bar.git\n' +
+              'fetch = +refs/heads/*:refs/remotes/origin/*',
+            refs: {
+              heads: {
+                master: 'this_is_the_sha'
+              }
+            }
+          },
+          'index.js': 'module.exports = 42;'
+        }
+      }
+    }
   }
 };

--- a/test/lib/github.js
+++ b/test/lib/github.js
@@ -58,3 +58,24 @@ test('malformed repository', function (t) {
 
   t.end();
 });
+
+test('enterprise repository', function (t) {
+
+  mock(mockRepo.enterprise);
+
+  t.equal(evaluate(function () {
+    /**
+     * get one
+     * @returns {number} one
+     */
+    function getOne() {
+      return 1;
+    }
+  })[0].context.github,
+  'https://github.enterprise.com/foo/bar/blob/this_is_the_sha/index.js#L6-L8',
+  'gets github enterprise url');
+
+  mock.restore();
+
+  t.end();
+});


### PR DESCRIPTION
`documentation` generates invalid links for GitHub Enterprise domains, because
[node-github-url-from-git](https://github.com/tj/node-github-url-from-git) returns `undefined` for such urls.

Possible solution is use `extraBaseUrls` option: https://github.com/tj/node-github-url-from-git/blob/3e20000ab2cfca0c17f6d19122e9f94135b45f98/test.js#L72
In this case github enterprise domain should be passed using additional command line option (e.g. `--github-domain`), but remote origin URL already contains needed information. Therefore I replaced [node-github-url-from-git](https://github.com/tj/node-github-url-from-git) to [git-url-parse](https://github.com/IonicaBizau/git-url-parse) (see https://github.com/documentationjs/documentation/issues/344).
