### PR TITLE
Add commands, update options and fix example

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -12,27 +12,34 @@ $ npm install -g documentation
 ```sh
 Usage: documentation <command> [options]
 
+Commands:
+  build   build documentation
+  serve   generate, update, and display HTML documentation
+  lint    check for common style and uniformity mistakes
+  readme  inject documentation into your README.md
+
 Options:
-  --lint             check output for common style and uniformity mistakes
-                                                                       [boolean]
-  -t, --theme        specify a theme: this must be a valid theme module
-  -p, --private      generate documentation tagged as private          [boolean]
-  --version          Show version number                               [boolean]
-  --name             project name. by default, inferred from package.json
-  --project-version  project version. by default, inferred from package.json
-  --shallow          shallow mode turns off dependency resolution, only
-                     processing the specified files (or the main script
-                     specified in package.json)       [boolean] [default: false]
-  --polyglot         polyglot mode turns off dependency resolution and enables
-                     multi-language support. use this to document c++  [boolean]
-  -g, --github       infer links to github in documentation            [boolean]
-  -o, --output       output location. omit for stdout, otherwise is a filename
-                     for single-file outputs and a directory name for multi-file
-                     outputs like html                       [default: "stdout"]
-  -c, --config       configuration file. an array defining explicit sort order
-  -h, --help         Show help                                         [boolean]
-  -f, --format                 [choices: "json", "md", "html"] [default: "json"]
+  --help           Show help                                           [boolean]
+  --version        Show version number                                 [boolean]
+  --shallow        shallow mode turns off dependency resolution, only processing
+                   the specified files (or the main script specified in
+                   package.json)                      [boolean] [default: false]
+  --config, -c     configuration file. an array defining explicit sort order
+  --external       a string / glob match pattern that defines which external
+                   modules will be whitelisted and included in the generated
+                   documentation.                                [default: null]
+  --extension, -e  only input source files matching this extension will be
+                   parsed, this option can be used multiple times.
+  --polyglot       polyglot mode turns off dependency resolution and enables
+                   multi-language support. use this to document c++    [boolean]
+  --private, -p    generate documentation tagged as private
+                                                      [boolean] [default: false]
+  --access, -a     Include only comments with a given access level, out of
+                   private, protected, public, undefined. By default, public,
+                   protected, and undefined access levels are included
+                        [choices: "public", "private", "protected", "undefined"]
+  --github, -g     infer links to github in documentation              [boolean]
 
 Examples:
-  documentation foo.js  parse documentation in a given file
+  documentation build foo.js  parse documentation in a given file
 ```


### PR DESCRIPTION
It looks like the list of options in USAGE.md is not up to date. The commands are not listed, and the example lacks a command. This pull request is an attempt to fix these issues.