### PR TITLE
Support js, jsx and es6 extensions by default

### DIFF
--- a/lib/filter_js.js
+++ b/lib/filter_js.js
@@ -20,7 +20,7 @@ function filterJS(extensions) {
   if (typeof extensions === 'string') {
     extensions = [extensions];
   }
-  extensions = extensions.concat('js');
+  extensions = extensions.concat(['js', 'es6', 'jsx']);
 
   return function (data) {
     return extensions.indexOf(path.extname(data.file).substring(1)) !== -1;

--- a/test/bin.js
+++ b/test/bin.js
@@ -98,10 +98,10 @@ test('external modules option', function (t) {
 });
 
 test('extension option', function (t) {
-  documentation(['build fixture/extension/jsx.jsx ' +
-    '--extension=jsx'], function (err, data) {
+  documentation(['build fixture/extension/index.otherextension ' +
+    '--extension=otherextension'], function (err, data) {
     t.ifError(err);
-    t.equal(data.length, 1, 'includes jsx file');
+    t.equal(data.length, 1, 'includes a file with an arbitrary extension');
     t.end();
   });
 });

--- a/test/fixture/extension/index.otherextension
+++ b/test/fixture/extension/index.otherextension
@@ -1,0 +1,12 @@
+/**
+ * apples
+ */
+function apples() {}
+
+var HelloMessage = React.createClass({
+  render: function() {
+    return <div>Hello {this.props.name}</div>;
+  }
+});
+
+ReactDOM.render(<HelloMessage name="John" />, mountNode);

--- a/test/fixture/extension/jsx.jsx
+++ b/test/fixture/extension/jsx.jsx
@@ -1,4 +1,0 @@
-/**
- * apples
- */
-function apples() {}

--- a/test/fixture/react-jsx.input.js
+++ b/test/fixture/react-jsx.input.js
@@ -1,0 +1,12 @@
+/**
+ * apples
+ */
+function apples() {}
+
+var HelloMessage = React.createClass({
+  render: function() {
+    return <div>Hello {this.props.name}</div>;
+  }
+});
+
+ReactDOM.render(<HelloMessage name="John" />, mountNode);

--- a/test/fixture/react-jsx.output.json
+++ b/test/fixture/react-jsx.output.json
@@ -1,0 +1,39 @@
+[
+  {
+    "description": "apples",
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 4,
+          "column": 20
+        }
+      },
+      "code": "/**\n * apples\n */\nfunction apples() {}\n\nvar HelloMessage = React.createClass({\n  render: function() {\n    return <div>Hello {this.props.name}</div>;\n  }\n});\n\nReactDOM.render(<HelloMessage name=\"John\" />, mountNode);\n"
+    },
+    "errors": [],
+    "name": "apples",
+    "kind": "function",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      "apples"
+    ]
+  }
+]

--- a/test/fixture/react-jsx.output.md
+++ b/test/fixture/react-jsx.output.md
@@ -1,0 +1,3 @@
+# apples
+
+apples

--- a/test/fixture/react-jsx.output.md.json
+++ b/test/fixture/react-jsx.output.md.json
@@ -1,0 +1,46 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "apples"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "apples",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 7
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 7
+        },
+        "indent": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #369 

This moves the existing JSX example to confirm that our default parsing of JSX is functional, and then changes the extension test to another extension that nobody will ever use to make sure that custom extension support works.