### PR TITLE
More correct parsing for kind shorthand (@class, @constant, etc)

### DIFF
--- a/lib/infer/kind.js
+++ b/lib/infer/kind.js
@@ -3,11 +3,8 @@
 var shouldSkipInference = require('./should_skip_inference');
 var t = require('babel-types');
 
-var kindShorthands = ['class', 'constant', 'event', 'external', 'file',
-  'function', 'member', 'mixin', 'module', 'namespace', 'typedef'];
-
 /**
- * Infers a `kind` tag from other tags or from the context.
+ * Infers a `kind` tag from the context.
  *
  * @name inferKind
  * @param {Object} comment parsed comment
@@ -17,15 +14,6 @@ module.exports = function () {
   return shouldSkipInference(function inferKind(comment) {
     if (comment.kind) {
       return comment;
-    }
-
-    for (var i = 0; i < kindShorthands.length; i++) {
-      var kind = kindShorthands[i];
-      if (kind in comment) {
-        comment.kind = kind;
-        // only allow a comment to have one kind
-        return comment;
-      }
     }
 
     function findKind(path) {

--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -72,7 +72,7 @@ module.exports = function () {
   var currentModule;
 
   function inferModuleName(comment) {
-    return (comment.module && comment.module.name) ||
+    return (comment.kind === 'module' && comment.name) ||
       pathParse(comment.context.file).name;
   }
 
@@ -121,7 +121,7 @@ module.exports = function () {
 
   return shouldSkipInference(function inferMembership(comment) {
 
-    if (comment.module) {
+    if (comment.kind === 'module') {
       currentModule = comment;
     }
 

--- a/lib/infer/name.js
+++ b/lib/infer/name.js
@@ -4,8 +4,7 @@ var shouldSkipInference = require('./should_skip_inference'),
   pathParse = require('parse-filepath');
 
 /**
- * Infers a `name` tag from the context,
- * and adopt `@class` and other other tags as implied name tags.
+ * Infers a `name` tag from the context.
  *
  * @name inferName
  * @param {Object} comment parsed comment
@@ -13,9 +12,7 @@ var shouldSkipInference = require('./should_skip_inference'),
  */
 module.exports = function () {
   return shouldSkipInference(function inferName(comment) {
-
-    if (comment.event) {
-      comment.name = comment.event;
+    if (comment.name) {
       return comment;
     }
 
@@ -24,23 +21,8 @@ module.exports = function () {
       return comment;
     }
 
-    if (comment.callback) {
-      comment.name = comment.callback;
-      return comment;
-    }
-
-    if (comment.class && comment.class.name) {
-      comment.name = comment.class.name;
-      return comment;
-    }
-
-    if (comment.module) {
-      comment.name = comment.module.name || pathParse(comment.context.file).name;
-      return comment;
-    }
-
-    if (comment.typedef) {
-      comment.name = comment.typedef.name;
+    if (comment.kind === 'module') {
+      comment.name = pathParse(comment.context.file).name;
       return comment;
     }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,11 +24,22 @@ var flatteners = {
   },
   'author': flattenDescription,
   'borrows': todo,
-  'callback': flattenDescription,
-  'class': flattenTypedName,
+  'callback': function (result, tag) {
+    result.kind = 'typedef';
+
+    if (tag.description) {
+      result.name = tag.description;
+    }
+
+    result.type = {
+      type: 'NameExpression',
+      name: 'Function'
+    };
+  },
+  'class': flattenKindShorthand,
   'classdesc': flattenMarkdownDescription,
   'const': synonym('constant'),
-  'constant': flattenTypedName,
+  'constant': flattenKindShorthand,
   'constructor': synonym('class'),
   'constructs': todo,
   'copyright': flattenMarkdownDescription,
@@ -39,7 +50,13 @@ var flatteners = {
   'description': flattenMarkdownDescription,
   'emits': synonym('fires'),
   'enum': todo,
-  'event': flattenDescription,
+  'event': function (result, tag) {
+    result.kind = 'event';
+
+    if (tag.description) {
+      result.name = tag.description;
+    }
+  },
   'example': function (result, tag) {
     if (!tag.description) {
       result.errors.push({
@@ -66,12 +83,24 @@ var flatteners = {
   'exception': synonym('throws'),
   'exports': todo,
   'extends': synonym('augments'),
-  'external': flattenDescription,
-  'file': flattenDescription,
+  'external': function (result, tag) {
+    result.kind = 'external';
+
+    if (tag.description) {
+      result.name = tag.description;
+    }
+  },
+  'file': function (result, tag) {
+    result.kind = 'file';
+
+    if (tag.description) {
+      result.description = parseMarkdown(tag.description);
+    }
+  },
   'fileoverview': synonym('file'),
   'fires': todo,
   'func': synonym('function'),
-  'function': flattenName,
+  'function': flattenKindShorthand,
   'global': function (result) {
     result.scope = 'global';
   },
@@ -97,14 +126,14 @@ var flatteners = {
   'lends': flattenDescription,
   'license': flattenDescription,
   'listens': todo,
-  'member': flattenTypedName,
+  'member': flattenKindShorthand,
   'memberof': flattenDescription,
   'method': synonym('function'),
   'mixes': todo,
-  'mixin': flattenName,
-  'module': flattenTypedName,
+  'mixin': flattenKindShorthand,
+  'module': flattenKindShorthand,
   'name': flattenName,
-  'namespace': flattenTypedName,
+  'namespace': flattenKindShorthand,
   'override': flattenBoolean,
   'overview': synonym('file'),
   'param': function (result, tag) {
@@ -212,7 +241,7 @@ var flatteners = {
   },
   'tutorial': todo,
   'type': todo,
-  'typedef': flattenTypedName,
+  'typedef': flattenKindShorthand,
   'var': synonym('member'),
   'variation': function (result, tag) {
     result.variation = tag.variation;
@@ -245,13 +274,15 @@ function flattenMarkdownDescription(result, tag, key) {
   result[key] = parseMarkdown(tag.description);
 }
 
-function flattenTypedName(result, tag, key) {
-  result[key] = {
-    name: tag.name
-  };
+function flattenKindShorthand(result, tag, key) {
+  result.kind = key;
+
+  if (tag.name) {
+    result.name = tag.name;
+  }
 
   if (tag.type) {
-    result[key].type = tag.type;
+    result.type = tag.type;
   }
 }
 

--- a/test/fixture/class.output.json
+++ b/test/fixture/class.output.json
@@ -95,9 +95,8 @@
       "code": "/**\n * This is my class, a demo thing.\n * @class MyClass\n * @property {number} howMany how many things it contains\n */\nfunction MyClass() {\n  this.howMany = 2;\n}\n\n/**\n * Get the number 42\n * @param {boolean} getIt whether to get the number\n * @returns {number} forty-two\n */\nMyClass.prototype.getFoo = function (getIt) {\n  return getIt ? 42 : 0;\n};\n\n/**\n * Get undefined\n * @returns {undefined} does not return anything.\n */\nMyClass.prototype.getUndefined = function () { };\n"
     },
     "errors": [],
-    "class": {
-      "name": "MyClass"
-    },
+    "kind": "class",
+    "name": "MyClass",
     "properties": [
       {
         "name": "howMany",
@@ -160,8 +159,6 @@
         }
       }
     ],
-    "name": "MyClass",
-    "kind": "class",
     "members": {
       "instance": [
         {

--- a/test/fixture/event.output.json
+++ b/test/fixture/event.output.json
@@ -111,7 +111,8 @@
       }
     },
     "errors": [],
-    "event": "Map#mousemove",
+    "kind": "event",
+    "name": "Map#mousemove",
     "properties": [
       {
         "name": "point",
@@ -234,8 +235,6 @@
         }
       }
     ],
-    "name": "Map#mousemove",
-    "kind": "event",
     "members": {
       "instance": [],
       "static": []

--- a/test/fixture/factory.output.json
+++ b/test/fixture/factory.output.json
@@ -192,11 +192,8 @@
       "code": "/**\n * an area chart generator\n * @returns {area} chart\n */\nvar area = function() {\n\n  /**\n   * @class area\n   */\n  var chart = function(selection) {\n  };\n\n  /**\n   * Sets the chart data.\n   * @function\n   */\n  chart.data = function(_) {\n  };\n\n  return chart;\n};\n"
     },
     "errors": [],
-    "class": {
-      "name": "area"
-    },
-    "name": "area",
     "kind": "class",
+    "name": "area",
     "params": [
       {
         "title": "param",
@@ -302,9 +299,8 @@
         "commentLineNumber": 0
       }
     ],
-    "function": null,
-    "name": "data",
     "kind": "function",
+    "name": "data",
     "params": [
       {
         "title": "param",

--- a/test/fixture/inheritance.output.json
+++ b/test/fixture/inheritance.output.json
@@ -39,9 +39,7 @@
         "commentLineNumber": 0
       }
     ],
-    "class": {
-      "name": "Foo"
-    },
+    "kind": "class",
     "name": "Foo",
     "augments": [
       {
@@ -49,7 +47,6 @@
         "name": "Bar"
       }
     ],
-    "kind": "class",
     "memberof": "module",
     "scope": "static",
     "members": {

--- a/test/fixture/memberedclass.output.json
+++ b/test/fixture/memberedclass.output.json
@@ -95,12 +95,9 @@
         "commentLineNumber": 4
       }
     ],
-    "class": {
-      "name": "MyClass"
-    },
-    "memberof": "com.Test",
-    "name": "MyClass",
     "kind": "class",
+    "name": "MyClass",
+    "memberof": "com.Test",
     "members": {
       "instance": [
         {

--- a/test/fixture/nearby_params.output.json
+++ b/test/fixture/nearby_params.output.json
@@ -142,7 +142,7 @@
       "code": "/** Attempt to establish a cookie-based session in exchange for credentials.\n *  @function\n *  @name sessions.create\n *  @param {object} credentials\n *  @param {string} credentials.name        Login username. Also accepted as `username` or `email`.\n *  @param {string} credentials.password    Login password\n *  @param {function} [callback]            Gets passed `(err, { success:Boolean })`.\n *  @returns {Promise} promise, to be resolved on success or rejected on failure\n */\nsessions.addMethod('create', 'POST / form', {\n    // normalize request body params\n    before({ body }) {\n    }\n});\n"
     },
     "errors": [],
-    "function": null,
+    "kind": "function",
     "name": "sessions.create",
     "params": [
       {

--- a/test/fixture/params.output.json
+++ b/test/fixture/params.output.json
@@ -177,9 +177,8 @@
       "code": "/**\n * This function returns the number one.\n * @param {number} b the second param\n */\nfunction addThem(a, b, c, { d, e, f }) {\n  return a + b + c + d + e + f;\n}\n\n/**\n * This method has partially inferred params\n * @param {String} $0.fishes number of kinds of fish\n */\nfunction fishesAndFoxes({ fishes, foxes }) {\n  return fishes + foxes;\n}\n\n/**\n * This method has a type in the description and a default in the code\n * @param {number} x\n */\nfunction withDefault(x = 2) {\n  return x;\n}\n\n/**\n * This is foo's documentation\n */\nclass Foo {\n  /**\n   * The method\n   * @param {number} x Param to method\n   */\n  method(x) {\n  }\n}\n\n/**\n * Represents an IPv6 address\n *\n * This tests  our support of optional parameters\n * @class Address6\n * @param {string} address - An IPv6 address string\n * @param {number} [groups=8] - How many octets to parse\n * @param {?number} third - A third argument\n * @param {Array} [foo=[1]] to properly be parsed\n * @example\n * var address = new Address6('2001::/32');\n */\nfunction Address6() {}\n\n/**\n * Create a GeoJSON data source instance given an options object\n *\n * This tests our support of nested parameters\n * @class GeoJSONSource\n * @param {Object} [options] optional options\n * @param {Object|string} options.data A GeoJSON data object or URL to it.\n * The latter is preferable in case of large GeoJSON files.\n * @param {number} [options.maxzoom=14] Maximum zoom to preserve detail at.\n * @param {number} [options.buffer] Tile buffer on each side.\n * @param {number} [options.tolerance] Simplification tolerance (higher means simpler).\n */\nfunction GeoJSONSource(options) {\n  this.options = options;\n}\n\n/**\n * This tests our support for parameters with explicit types but with default\n * values specified in code.\n *\n * @param {number} x an argument\n *\n * @returns {number} some\n */\nexport const myfunc = (x = 123) => x;\n\n/**\n * This tests our support of JSDoc param tags without type information,\n * or any type information we could infer from annotations.\n *\n * @param address - An IPv6 address string\n */\nfunction foo(address) {\n  return address;\n}\n"
     },
     "errors": [],
-    "class": {
-      "name": "Address6"
-    },
+    "kind": "class",
+    "name": "Address6",
     "params": [
       {
         "name": "address",
@@ -437,8 +436,6 @@
         "description": "var address = new Address6('2001::/32');"
       }
     ],
-    "name": "Address6",
-    "kind": "class",
     "members": {
       "instance": [],
       "static": []
@@ -1423,9 +1420,8 @@
       "code": "/**\n * This function returns the number one.\n * @param {number} b the second param\n */\nfunction addThem(a, b, c, { d, e, f }) {\n  return a + b + c + d + e + f;\n}\n\n/**\n * This method has partially inferred params\n * @param {String} $0.fishes number of kinds of fish\n */\nfunction fishesAndFoxes({ fishes, foxes }) {\n  return fishes + foxes;\n}\n\n/**\n * This method has a type in the description and a default in the code\n * @param {number} x\n */\nfunction withDefault(x = 2) {\n  return x;\n}\n\n/**\n * This is foo's documentation\n */\nclass Foo {\n  /**\n   * The method\n   * @param {number} x Param to method\n   */\n  method(x) {\n  }\n}\n\n/**\n * Represents an IPv6 address\n *\n * This tests  our support of optional parameters\n * @class Address6\n * @param {string} address - An IPv6 address string\n * @param {number} [groups=8] - How many octets to parse\n * @param {?number} third - A third argument\n * @param {Array} [foo=[1]] to properly be parsed\n * @example\n * var address = new Address6('2001::/32');\n */\nfunction Address6() {}\n\n/**\n * Create a GeoJSON data source instance given an options object\n *\n * This tests our support of nested parameters\n * @class GeoJSONSource\n * @param {Object} [options] optional options\n * @param {Object|string} options.data A GeoJSON data object or URL to it.\n * The latter is preferable in case of large GeoJSON files.\n * @param {number} [options.maxzoom=14] Maximum zoom to preserve detail at.\n * @param {number} [options.buffer] Tile buffer on each side.\n * @param {number} [options.tolerance] Simplification tolerance (higher means simpler).\n */\nfunction GeoJSONSource(options) {\n  this.options = options;\n}\n\n/**\n * This tests our support for parameters with explicit types but with default\n * values specified in code.\n *\n * @param {number} x an argument\n *\n * @returns {number} some\n */\nexport const myfunc = (x = 123) => x;\n\n/**\n * This tests our support of JSDoc param tags without type information,\n * or any type information we could infer from annotations.\n *\n * @param address - An IPv6 address string\n */\nfunction foo(address) {\n  return address;\n}\n"
     },
     "errors": [],
-    "class": {
-      "name": "GeoJSONSource"
-    },
+    "kind": "class",
+    "name": "GeoJSONSource",
     "params": [
       {
         "name": "options",
@@ -1755,8 +1751,6 @@
         ]
       }
     ],
-    "name": "GeoJSONSource",
-    "kind": "class",
     "members": {
       "instance": [],
       "static": []

--- a/test/fixture/trailing.output.json
+++ b/test/fixture/trailing.output.json
@@ -400,11 +400,8 @@
       }
     },
     "errors": [],
-    "class": {
-      "name": "Something"
-    },
-    "name": "Something",
     "kind": "class",
+    "name": "Something",
     "members": {
       "instance": [],
       "static": []

--- a/test/fixture/type_application.output.json
+++ b/test/fixture/type_application.output.json
@@ -103,9 +103,8 @@
       }
     },
     "errors": [],
-    "class": {
-      "name": "Address6"
-    },
+    "kind": "class",
+    "name": "Address6",
     "params": [
       {
         "name": "address",
@@ -177,8 +176,6 @@
         }
       }
     ],
-    "name": "Address6",
-    "kind": "class",
     "members": {
       "instance": [],
       "static": []

--- a/test/fixture/typedef.output.json
+++ b/test/fixture/typedef.output.json
@@ -114,12 +114,10 @@
     },
     "errors": [],
     "name": "MyType",
-    "typedef": {
-      "name": "MyType",
-      "type": {
-        "type": "NameExpression",
-        "name": "Object"
-      }
+    "kind": "typedef",
+    "type": {
+      "type": "NameExpression",
+      "name": "Object"
     },
     "properties": [
       {

--- a/test/lib/infer/kind.js
+++ b/test/lib/infer/kind.js
@@ -17,13 +17,6 @@ test('inferKind', function (t) {
     tags: []
   }).kind, 'class', 'explicit');
 
-  ['class', 'constant', 'event', 'external', 'file',
-    'function', 'member', 'mixin', 'module', 'namespace', 'typedef'].forEach(function (tag) {
-      var comment = { tags: [] };
-      comment[tag] = true;
-      t.equal(inferKind(comment).kind, tag, 'from ' + tag + ' keyword');
-    });
-
   t.equal(inferKind(toComment(function () {
     /** function */
     function foo() { }

--- a/test/lib/parse.js
+++ b/test/lib/parse.js
@@ -3,7 +3,8 @@
 var test = require('tap').test,
   parse = require('../../lib/parsers/javascript'),
   remark = require('remark'),
-  visit = require('unist-util-visit');
+  visit = require('unist-util-visit'),
+  _ = require('lodash');
 
 function evaluate(fn, filename) {
   return parse({
@@ -72,17 +73,44 @@ test('parse - @borrows', function (t) {
 });
 
 test('parse - @callback', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
     /** @callback name */
-  })[0].callback, 'name', 'callback');
+  })[0], 'kind', 'name', 'type'), {
+    name: 'name',
+    kind: 'typedef',
+    type: {
+      type: 'NameExpression',
+      name: 'Function'
+    }
+  });
 
   t.end();
 });
 
 test('parse - @class', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @class */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'class'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
     /** @class name */
-  })[0].class.name, 'name', 'class');
+  })[0], 'kind', 'name', 'type'), {
+    name: 'name',
+    kind: 'class'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @class {Object} name */
+  })[0], 'kind', 'name', 'type'), {
+    name: 'name',
+    kind: 'class',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
 
   t.end();
 });
@@ -100,9 +128,40 @@ test('parse - @const', function (t) {
 });
 
 test('parse - @constant', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @constant */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'constant'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
     /** @constant name */
-  })[0].constant.name, 'name', 'constant');
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'constant',
+    name: 'name'
+  });
+
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @constant {Object} */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'constant',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @constant {Object} name */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'constant',
+    name: 'name',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
 
   t.end();
 });
@@ -172,9 +231,12 @@ test('parse - @enum', function (t) {
 });
 
 test('parse - @event', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
     /** @event name */
-  })[0].event, 'name', 'event');
+  })[0], 'kind', 'name'), {
+    kind: 'event',
+    name: 'name'
+  });
 
   t.end();
 });
@@ -234,17 +296,29 @@ test('parse - @extends', function (t) {
 });
 
 test('parse - @external', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
     /** @external name */
-  })[0].external, 'name', 'external');
+  })[0], 'kind', 'name'), {
+    kind: 'external',
+    name: 'name'
+  });
 
   t.end();
 });
 
 test('parse - @file', function (t) {
-  t.equal(evaluate(function () {
-    /** @file name */
-  })[0].file, 'name', 'file');
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @file */
+  })[0], 'kind'), {
+    kind: 'file'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @file desc */
+  })[0], 'kind', 'description'), {
+    kind: 'file',
+    description: remark.parse('desc')
+  });
 
   t.end();
 });
@@ -262,9 +336,18 @@ test('parse - @func', function (t) {
 });
 
 test('parse - @function', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @function */
+  })[0], 'kind', 'name'), {
+    kind: 'function'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
     /** @function name */
-  })[0].function, 'name', 'function');
+  })[0], 'kind', 'name'), {
+    kind: 'function',
+    name: 'name'
+  });
 
   t.end();
 });
@@ -350,9 +433,39 @@ test('parse - @listens', function (t) {
 });
 
 test('parse - @member', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @member */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'member'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
     /** @member name */
-  })[0].member.name, 'name', 'member');
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'member',
+    name: 'name'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @member {Object} */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'member',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @member {Object} name */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'member',
+    name: 'name',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
 
   t.end();
 });
@@ -374,24 +487,46 @@ test('parse - @mixes', function (t) {
 });
 
 test('parse - @mixin', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @mixin */
+  })[0], 'kind', 'name'), {
+    kind: 'mixin'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
     /** @mixin name */
-  })[0].mixin, 'name', 'mixin');
+  })[0], 'kind', 'name'), {
+    kind: 'mixin',
+    name: 'name'
+  });
 
   t.end();
 });
 
 test('parse - @module', function (t) {
-  t.equal(evaluate(function () {
-    /** @module name */
-  })[0].module.name, 'name', 'module');
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @module */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'module'
+  });
 
-  t.deepEqual(evaluate(function () {
-    /** @module {string} name */
-  })[0].module.type, {
-    type: 'NameExpression',
-    name: 'string'
-  }, 'typed name');
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @module name */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'module',
+    name: 'name'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @module {Object} name */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'module',
+    name: 'name',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
 
   t.end();
 });
@@ -405,9 +540,29 @@ test('parse - @name', function (t) {
 });
 
 test('parse - @namespace', function (t) {
-  t.equal(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @namespace */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'namespace'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
     /** @namespace name */
-  })[0].namespace.name, 'name', 'namespace');
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'namespace',
+    name: 'name'
+  });
+
+  t.deepEqual(_.pick(evaluate(function () {
+    /** @namespace {Object} name */
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'namespace',
+    name: 'name',
+    type: {
+      type: 'NameExpression',
+      name: 'Object'
+    }
+  });
 
   t.end();
 });
@@ -697,15 +852,16 @@ test('parse - @type', function (t) {
 });
 
 test('parse - @typedef', function (t) {
-  t.deepEqual(evaluate(function () {
+  t.deepEqual(_.pick(evaluate(function () {
     /** @typedef {Object} name */
-  })[0].typedef, {
+  })[0], 'kind', 'name', 'type'), {
+    kind: 'typedef',
     name: 'name',
     type: {
       type: 'NameExpression',
       name: 'Object'
     }
-  }, 'namespace');
+  });
 
   t.end();
 });


### PR DESCRIPTION
* Set the `kind` property of the comment, not a property named by the kind.
* Set the `type` property as appropriate for these shorthands.
* Parse `@callback` as shorthand for `@typedef {Function}`

These changes bring the comment JSON into closer alignment with the [schema](https://github.com/documentationjs/documentation-schema). They also further consolidate tag-specific code in the handler map in parse.js, leaving the `infer` routines handling only AST-based inference.

cc @tmcw 