### PR TITLE
Add failing test for .jsx dependency

### DIFF
--- a/test/bin.js
+++ b/test/bin.js
@@ -128,6 +128,13 @@ test('extension option', function (t) {
   });
 });
 
+test('extension option', function (t) {
+  documentation(['build fixture/extension.jsx'], function (err, data) {
+    t.ifError(err);
+    t.end();
+  });
+});
+
 test('invalid arguments', function (group) {
   group.test('bad -f option', function (t) {
     documentation(['build -f DOES-NOT-EXIST fixture/internal.input.js'], function (err) {

--- a/test/fixture/extension.jsx
+++ b/test/fixture/extension.jsx
@@ -1,0 +1,1 @@
+var required = require('./extension-required');

--- a/test/fixture/extension/extension-required.jsx
+++ b/test/fixture/extension/extension-required.jsx
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
`Error: Cannot find module './extension-required' from '/Users/stephencollings/workspace/documentation/test/fixture'`

According to https://github.com/documentationjs/documentation/issues/369 this should work but doesn't seem to. Any pointers anyone?

Thanks

