### PR TITLE
Prevent double call to require when theme is set + jsdoc fixes

### DIFF
--- a/lib/output/html.js
+++ b/lib/output/html.js
@@ -5,18 +5,20 @@ var path = require('path');
 /**
  * Formats documentation as HTML.
  *
- * @param {Array<Object>} comments parsed comments
+ * @param {Array<Object>} comments Parsed comments.
  * @param {Object} options Options that can customize the output
  * @param {string} [options.theme='documentation-theme-default'] Name of a module used for an HTML theme.
- * @param {Function} callback called with array of results as vinyl-fs objects
- * @returns {undefined} calls callback
+ * @param {Function} callback Called with array of results as vinyl-fs objects.
+ * @returns {undefined} Calls callback.
  * @name html
  */
 module.exports = function makeHTML(comments, options, callback) {
   options = options || {};
-  var theme = require('documentation-theme-default');
+  var theme;
   if (options.theme) {
     theme = require(path.resolve(process.cwd(), options.theme));
+  } else {
+    theme = require('documentation-theme-default');
   }
   theme(comments, options, callback);
 };


### PR DESCRIPTION
- Updates html.js to not double call require when theme is set.
- Normalizes jsdoc comments.