### PR TITLE
feat: add decorator support

### DIFF
--- a/lib/input/dependency.js
+++ b/lib/input/dependency.js
@@ -33,6 +33,9 @@ function dependencyStream(indexes, options, callback) {
         require('babel-preset-es2015'),
         require('babel-preset-stage-0'),
         require('babel-preset-react')
+      ],
+      plugins: [
+        require('babel-plugin-transform-decorators-legacy').default
       ]
     })],
     postFilter: moduleFilters.externals(indexes, options)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "ansi-html": "0.0.5",
     "babel-core": "^6.5.2",
+    "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
This PR adds experimental decorator support via the [transform-decorators-legacy](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy) plugin.

--

Closes #414