### PR TITLE
No context for narrative sections

### DIFF
--- a/lib/output/markdown_ast.js
+++ b/lib/output/markdown_ast.js
@@ -126,7 +126,7 @@ function commentsToAST(comments, opts, callback) {
     }
 
     function githubLink(comment) {
-      return comment.context.github && u('paragraph', [
+      return comment.context && comment.context.github && u('paragraph', [
         u('link', {
           title: 'Source code on GitHub',
           url: comment.context.github


### PR DESCRIPTION
When using `--config configuration.yml` with narrative sections, `documentation build -f md` crashes with `TypeError: Cannot read property 'github' of undefined` (regardless if `--github` is passed or not).

Verify that the `comment.context` object exists before reading its properties.