### PR TITLE
Infer name for string-literal property keys

### DIFF
--- a/lib/infer/name.js
+++ b/lib/infer/name.js
@@ -31,6 +31,10 @@ module.exports = function () {
         comment.name = node.name;
         return true;
       }
+      if (node && node.type === 'StringLiteral' && node.value) {
+        comment.name = node.value;
+        return true;
+      }
     }
 
     if (comment.context.ast) {
@@ -55,6 +59,21 @@ module.exports = function () {
         Identifier: function (path) {
           if (inferName(path, path.node)) {
             path.stop();
+          }
+        },
+        /**
+         * Attempt to extract the name from a string literal that is the `key`
+         * part of an ObjectProperty node.  If the name can be resolved, it
+         * will stop traversing.
+         * @param {Object} path ast path
+         * @returns {undefined} has side-effects
+         * @private
+         */
+        StringLiteral: function (path) {
+          if (path.parent.type === 'ObjectProperty' && path.node === path.parent.key) {
+            if (inferName(path, path.node)) {
+              path.stop();
+            }
           }
         },
         /**

--- a/test/fixture/string-literal-key.input.js
+++ b/test/fixture/string-literal-key.input.js
@@ -1,0 +1,11 @@
+/**
+ * @alias MyContainerObject
+ */
+const obj = {
+  /**
+   * The foo property
+   */
+  'foo': {
+    bar: 0
+  }
+}

--- a/test/fixture/string-literal-key.output.json
+++ b/test/fixture/string-literal-key.output.json
@@ -1,0 +1,141 @@
+[
+  {
+    "description": "",
+    "tags": [
+      {
+        "title": "alias",
+        "description": null,
+        "lineNumber": 1,
+        "name": "MyContainerObject"
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 3,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 4,
+          "column": 0
+        },
+        "end": {
+          "line": 11,
+          "column": 1
+        }
+      },
+      "code": "/**\n * @alias MyContainerObject\n */\nconst obj = {\n  /**\n   * The foo property\n   */\n  'foo': {\n    bar: 0\n  }\n}\n"
+    },
+    "errors": [],
+    "alias": "MyContainerObject",
+    "name": "MyContainerObject",
+    "kind": "constant",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "MyContainerObject",
+        "kind": "constant"
+      }
+    ],
+    "namespace": "MyContainerObject"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The foo property",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 17,
+                  "offset": 16
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 17,
+              "offset": 16
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 17,
+          "offset": 16
+        }
+      }
+    },
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 5,
+        "column": 2
+      },
+      "end": {
+        "line": 7,
+        "column": 5
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 8,
+          "column": 2
+        },
+        "end": {
+          "line": 10,
+          "column": 3
+        }
+      },
+      "code": "/**\n * @alias MyContainerObject\n */\nconst obj = {\n  /**\n   * The foo property\n   */\n  'foo': {\n    bar: 0\n  }\n}\n"
+    },
+    "errors": [],
+    "name": "foo",
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "foo"
+      }
+    ],
+    "namespace": "foo"
+  }
+]

--- a/test/fixture/string-literal-key.output.md
+++ b/test/fixture/string-literal-key.output.md
@@ -1,0 +1,5 @@
+# MyContainerObject
+
+# foo
+
+The foo property

--- a/test/fixture/string-literal-key.output.md.json
+++ b/test/fixture/string-literal-key.output.md.json
@@ -1,0 +1,60 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "MyContainerObject"
+        }
+      ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "foo"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "The foo property",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 17,
+              "offset": 16
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 17,
+          "offset": 16
+        },
+        "indent": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Before this change, object properties like the one below would get the name of
a nested property:

```js
{
  /**
   * This node ends up getting the name 'normalKey' instead of 'string-literal-key'
   */
  'string-literal-key': {
    normalKey: 5
  }
}
```