### PR TITLE
Fix issue where exported declarations did not set the kind

### DIFF
--- a/lib/infer/kind.js
+++ b/lib/infer/kind.js
@@ -39,10 +39,12 @@ function inferKind() {
           // This behavior is in need of fixing https://github.com/documentationjs/documentation/issues/351
           findKind(node.declarations[0].init);
         }
-      } else if (t.isExportNamedDeclaration(node)) {
+      } else if (t.isExportDeclaration(node)) {
         // export var x = ...
         // export function f() {}
         // export class C {}
+        // export default function f() {}
+        // export default class C {}
         findKind(node.declaration);
       } else if (t.isExpressionStatement(node)) {
         // module.exports = function() {}

--- a/lib/infer/kind.js
+++ b/lib/infer/kind.js
@@ -15,47 +15,49 @@ function inferKind() {
       return comment;
     }
 
-    function findKind(path) {
-      if (!path) {
+    function findKind(node) {
+      if (!node) {
         return comment;
-      } else if (t.isClassDeclaration(path)) {
+      }
+
+      if (t.isClassDeclaration(node)) {
         comment.kind = 'class';
-      } else if (t.isFunction(path)) {
-        if (path.node && (path.node.kind === 'get' || path.node.kind === 'set')) {
+      } else if (t.isFunction(node)) {
+        if (node.kind === 'get' || node.kind === 'set') {
           comment.kind = 'member';
-        } else if (path.node && path.node.id && path.node.id.name && !!/^[A-Z]/.exec(path.node.id.name)) {
+        } else if (node.id && node.id.name && !!/^[A-Z]/.exec(node.id.name)) {
           comment.kind = 'class';
         } else {
           comment.kind = 'function';
         }
-      } else if (t.isTypeAlias(path)) {
+      } else if (t.isTypeAlias(node)) {
         comment.kind = 'typedef';
-      } else if (t.isVariableDeclaration(path)) {
-        if (path.node.kind === 'const') {
+      } else if (t.isVariableDeclaration(node)) {
+        if (node.kind === 'const') {
           comment.kind = 'constant';
         } else {
           // This behavior is in need of fixing https://github.com/documentationjs/documentation/issues/351
-          findKind(path.node.declarations[0].init);
+          findKind(node.declarations[0].init);
         }
-      } else if (t.isExportNamedDeclaration(path) && path.node.declaration) {
-        // && makes sure that
-        // export { foo } from bar;
-        // doesn't check for a non-existent declaration type
-        if (path.node.declaration.kind === 'const') {
-          comment.kind = 'constant';
-        }
-      } else if (t.isExpressionStatement(path)) {
+      } else if (t.isExportNamedDeclaration(node)) {
+        // export var x = ...
+        // export function f() {}
+        // export class C {}
+        findKind(node.declaration);
+      } else if (t.isExpressionStatement(node)) {
         // module.exports = function() {}
-        findKind(path.node.expression.right);
-      } else if (t.isClassProperty(path)) {
+        findKind(node.expression.right);
+      } else if (t.isClassProperty(node)) {
         comment.kind = 'member';
-      } else if (t.isProperty(path)) {
+      } else if (t.isProperty(node)) {
         // { foo: function() {} }
-        findKind(path.node.value);
+        findKind(node.value);
       }
     }
 
-    findKind(comment.context.ast);
+    if (comment.context.ast) {
+      findKind(comment.context.ast.node);
+    }
 
     return comment;
   });

--- a/test/fixture/es6-import.output.json
+++ b/test/fixture/es6-import.output.json
@@ -2188,6 +2188,7 @@
     "errors": [],
     "access": "public",
     "name": "es6.input",
+    "kind": "function",
     "params": [
       {
         "title": "param",
@@ -2201,7 +2202,8 @@
     },
     "path": [
       {
-        "name": "es6.input"
+        "name": "es6.input",
+        "kind": "function"
       }
     ],
     "namespace": "es6.input"

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -1931,6 +1931,7 @@
     "errors": [],
     "access": "public",
     "name": "es6.input",
+    "kind": "function",
     "params": [
       {
         "title": "param",
@@ -1944,7 +1945,8 @@
     },
     "path": [
       {
-        "name": "es6.input"
+        "name": "es6.input",
+        "kind": "function"
       }
     ],
     "namespace": "es6.input"

--- a/test/lib/infer/kind.js
+++ b/test/lib/infer/kind.js
@@ -29,6 +29,12 @@ test('inferKind', function (t) {
     ' */' +
     'export class C {}')).kind, 'class', 'es6 syntax with export');
 
+  t.equal(inferKind(toComment(
+    '/**' +
+    ' * Export default class' +
+    ' */' +
+    'export default class C {}')).kind, 'class', 'es6 syntax with default export');
+
   t.equal(inferKind(toComment(function () {
     /** function */
     function foo() { }
@@ -44,6 +50,10 @@ test('inferKind', function (t) {
   t.equal(inferKind(toComment(
     '/** Exported function */' +
     'export function foo() {}')).kind, 'function', 'inferred exported function');
+
+  t.equal(inferKind(toComment(
+    '/** Export default function */' +
+    'export default function foo() {}')).kind, 'function', 'inferred exported function');
 
   t.equal(inferKind(toComment(
     'class Foo { /** set b */ set b(v) { } }'
@@ -80,7 +90,7 @@ test('inferKind', function (t) {
     '/**' +
     ' * Exported constant' +
     ' */' +
-    'export const foo = "bar";')).kind, 'constant', 'constant via const');
+    'export const foo = "bar";')).kind, 'constant', 'constant via export const');
 
   t.end();
 });

--- a/test/lib/infer/kind.js
+++ b/test/lib/infer/kind.js
@@ -17,6 +17,18 @@ test('inferKind', function (t) {
     tags: []
   }).kind, 'class', 'explicit');
 
+  t.equal(inferKind(toComment(
+    '/**' +
+    ' * Class' +
+    ' */' +
+    'class C {}')).kind, 'class', 'es6 syntax');
+
+  t.equal(inferKind(toComment(
+    '/**' +
+    ' * Exported class' +
+    ' */' +
+    'export class C {}')).kind, 'class', 'es6 syntax with export');
+
   t.equal(inferKind(toComment(function () {
     /** function */
     function foo() { }
@@ -28,6 +40,10 @@ test('inferKind', function (t) {
     var foo = function () { };
     foo();
   })).kind, 'function', 'inferred var function');
+
+  t.equal(inferKind(toComment(
+    '/** Exported function */' +
+    'export function foo() {}')).kind, 'function', 'inferred exported function');
 
   t.equal(inferKind(toComment(
     'class Foo { /** set b */ set b(v) { } }'
@@ -59,5 +75,12 @@ test('inferKind', function (t) {
     ' * This is a constant called foo' +
     ' */' +
     'const foo = "bar";')).kind, 'constant', 'constant via const');
+
+  t.equal(inferKind(toComment(
+    '/**' +
+    ' * Exported constant' +
+    ' */' +
+    'export const foo = "bar";')).kind, 'constant', 'constant via const');
+
   t.end();
 });


### PR DESCRIPTION
For cases like:

```js
/** */ export class C {}
/** */ export function f {}
/** */ export const k = 42;
```

the kind did not get set properly.

Towards #484