### PR TITLE
Use provided name for export default

### DIFF
--- a/lib/infer/name.js
+++ b/lib/infer/name.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var shouldSkipInference = require('./should_skip_inference'),
-  pathParse = require('parse-filepath');
+  pathParse = require('parse-filepath'),
+  t = require('babel-types');
 
 /**
  * Infers a `name` tag from the context.
@@ -37,9 +38,14 @@ module.exports = function () {
       }
     }
 
-    if (comment.context.ast) {
-      if (comment.context.ast.type === 'ExportDefaultDeclaration') {
-        comment.name = pathParse(comment.context.file).name;
+    var path = comment.context.ast;
+    if (path) {
+      if (path.type === 'ExportDefaultDeclaration') {
+        if (t.isDeclaration(path.node.declaration) && path.node.declaration.id) {
+          comment.name = path.node.declaration.id.name;
+        } else {
+          comment.name = pathParse(comment.context.file).name;
+        }
         return comment;
       }
 
@@ -48,7 +54,7 @@ module.exports = function () {
       // For example, name inference for a MemberExpression `foo.bar = baz` will
       // infer the named based on the `property` of the MemberExpression (`bar`)
       // rather than the `object` (`foo`).
-      comment.context.ast.traverse({
+      path.traverse({
         /**
          * Attempt to extract the name from an Identifier node.
          * If the name can be resolved, it will stop traversing.

--- a/test/lib/infer/name.js
+++ b/test/lib/infer/name.js
@@ -125,12 +125,21 @@ test('inferName', function (t) {
 
   t.equal(evaluate('/** Test */ export function exported() {}').name, 'exported');
 
-  t.equal(evaluate('/** Test */ export default function exported() {}',
+  t.equal(evaluate('/** Test */ export default function() {}',
     '/path/inferred-from-file.js').name, 'inferred-from-file');
+
+  t.equal(evaluate('/** Test */ export default function exported() {}',
+    '/path/inferred-from-file.js').name, 'exported');
 
   t.equal(evaluate('/** Test */ export var life = 42;').name, 'life');
 
   t.equal(evaluate('/** Test */ export class Wizard {}').name, 'Wizard');
+
+  t.equal(evaluate('/** Test */ export default class Warlock {}',
+    '/path/inferred-from-file.js').name, 'Warlock');
+
+  t.equal(evaluate('/** Test */ export default class {}',
+    '/path/inferred-from-file.js').name, 'inferred-from-file');
 
   t.end();
 });


### PR DESCRIPTION
If a binding name is provided we should use that in the documentation.

For example:

```js
// test.js
/** */
export default function find() {}
```

Should use the name `find` and not `test`.

Fixes #504