### PR TITLE
Fix the name of infer membership for non named export default

### DIFF
--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -157,19 +157,16 @@ module.exports = function () {
     var path = comment.context.ast;
     var identifiers;
 
-    /*
-     * Deal with an oddity of espree: the jsdoc comment is attached to a different
-     * node in the two expressions `a.b = c` vs `a.b = function () {}`.
-     */
+
+    // Deal with an oddity of espree: the jsdoc comment is attached to a different
+    // node in the two expressions `a.b = c` vs `a.b = function () {}`.
     if (n.isExpressionStatement(path.node) &&
         n.isAssignmentExpression(path.node.expression) &&
         n.isMemberExpression(path.node.expression.left)) {
       path = path.get('expression').get('left');
     }
 
-    /*
-     * Same as above but for `b: c` vs `b: function () {}`.
-     */
+    // Same as above but for `b: c` vs `b: function () {}`.
     if (n.isObjectProperty(path.node) &&
         n.isIdentifier(path.node.key)) {
       path = path.get('key');
@@ -230,7 +227,15 @@ module.exports = function () {
       if (n.isExpression(path.parentPath.parentPath)) {
         identifiers = extractIdentifiers(path.parentPath.parentPath.parentPath.get('left'));
       } else {
-        identifiers = [path.parentPath.parentPath.node.id.name];
+        var declarationNode = path.parentPath.parentPath.node;
+        if (!declarationNode.id) {
+          // export default function () {}
+          // export default class {}
+          // Use module name instead.
+          identifiers = [pathParse(comment.context.file).name];
+        } else {
+          identifiers = [declarationNode.id.name];
+        }
       }
       var scope = 'instance';
       if (path.node.static == true) {

--- a/test/lib/infer/membership.js
+++ b/test/lib/infer/membership.js
@@ -380,3 +380,40 @@ test('inferMembership - https://github.com/documentationjs/documentation/issues/
 
   t.end();
 });
+
+test('inferMembership - export', function (t) {
+  t.deepEqual(pick(evaluate(
+    'export default class {' +
+    '  /** */' +
+    '  method() {}' +
+    '}',
+    'test-file'
+  )[0], ['memberof', 'scope']), {
+    memberof: 'test-file',
+    scope: 'instance'
+  });
+
+  t.deepEqual(pick(evaluate(
+    'export default class C {' +
+    '  /** */' +
+    '  method() {}' +
+    '}',
+    'test-file'
+  )[0], ['memberof', 'scope']), {
+    memberof: 'C',
+    scope: 'instance'
+  });
+
+  t.deepEqual(pick(evaluate(
+    'export class C {' +
+    '  /** */' +
+    '  method() {}' +
+    '}',
+    'test-file'
+  )[0], ['memberof', 'scope']), {
+    memberof: 'C',
+    scope: 'instance'
+  });
+
+  t.end();
+});


### PR DESCRIPTION
When inferring the membership of a class that is an unnamed default
export we hit a null pointer exception.

```js
export default class {
  /** */
  member() {}
}
```

Inferring the name for the class above fails

Fixes #506