### PR TITLE
Handle flow tuple syntax

### DIFF
--- a/lib/flow_doctrine.js
+++ b/lib/flow_doctrine.js
@@ -29,7 +29,6 @@ var literalTypes = {
  * @returns {Object} doctrine compatible type
  */
 function flowDoctrine(type) {
-
   if (type.type in namedTypes) {
     return {
       type: 'NameExpression',
@@ -41,22 +40,38 @@ function flowDoctrine(type) {
     return oneToOne[type.type];
   }
 
-  if (type.type === 'NullableTypeAnnotation') {
+  switch (type.type) {
+  case 'NullableTypeAnnotation':
     return {
       type: 'NullableType',
       expression: flowDoctrine(type.typeAnnotation)
     };
-  }
-
-  if (type.type === 'UnionTypeAnnotation') {
+  case 'UnionTypeAnnotation':
     return {
       type: 'UnionType',
       elements: type.types.map(flowDoctrine)
     };
-  }
 
-  if (type.type === 'GenericTypeAnnotation') {
+  // [number]
+  // [string, boolean, number]
+  case 'TupleTypeAnnotation':
+    return {
+      type: 'ArrayType',
+      elements: type.types.map(flowDoctrine)
+    };
 
+  // number[]
+  case 'ArrayTypeAnnotation':
+    return {
+      type: 'TypeApplication',
+      expression: {
+        type: 'NameExpression',
+        name: 'Array'
+      },
+      applications: [flowDoctrine(type.elementType)]
+    };
+
+  case 'GenericTypeAnnotation':
     if (type.typeParameters) {
       return {
         type: 'TypeApplication',

--- a/test/lib/flow_doctrine.js
+++ b/test/lib/flow_doctrine.js
@@ -11,35 +11,33 @@ function toComment(fn, filename) {
   })[0];
 }
 
+function toDoctrineType(flowType) {
+  return flowDoctrine(toComment(
+      '/** add */function add(a: ' + flowType + ' ) { }'
+    ).context.ast.node.params[0].typeAnnotation.typeAnnotation);
+}
+
 /* eslint-disable */
 test('flowDoctrine', function (t) {
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: number) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('number'),
     {
       type: 'NameExpression',
       name: 'number'
     }, 'number');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: string) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('string'),
     {
       type: 'NameExpression',
       name: 'string'
     }, 'string');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: any) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('any'),
     {
       type: 'AllLiteral'
     }, 'all');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: ?number) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('?number'),
     {
       type: 'NullableType',
       expression: {
@@ -48,9 +46,7 @@ test('flowDoctrine', function (t) {
       }
     }, 'nullable');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: number | string) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('number | string'),
     {
       type: 'UnionType',
       elements: [
@@ -65,25 +61,19 @@ test('flowDoctrine', function (t) {
       ]
     }, 'union');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: Object) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('Object'),
     {
       type: 'NameExpression',
       name: 'Object'
     }, 'object');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: Array) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('Array'),
     {
       type: 'NameExpression',
       name: 'Array'
     }, 'array');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: Array<number>) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('Array<number>'),
     {
       type: 'TypeApplication',
       expression: {
@@ -96,45 +86,88 @@ test('flowDoctrine', function (t) {
       }]
     }, 'Array<number>');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: boolean) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('number[]'),
+    {
+      type: 'TypeApplication',
+      expression: {
+        type: 'NameExpression',
+        name: 'Array'
+      },
+      applications: [{
+        type: 'NameExpression',
+        name: 'number'
+      }]
+    }, 'number[]');
+
+    t.deepEqual(toDoctrineType('[]'),
+      {
+        type: 'ArrayType',
+        elements: []
+      }, '[]');
+
+    t.deepEqual(toDoctrineType('[number]'),
+      {
+        type: 'ArrayType',
+        elements: [
+          {
+            type: 'NameExpression',
+            name: 'number'
+          }
+        ]
+      }, '[number]');
+
+    t.deepEqual(toDoctrineType('[string, boolean]'),
+      {
+        type: 'ArrayType',
+        elements: [
+          {
+            type: 'NameExpression',
+            name: 'string'
+          },
+          {
+            type: 'NameExpression',
+            name: 'boolean'
+          }
+        ]
+      }, '[string, boolean]');
+
+
+  t.deepEqual(toDoctrineType('boolean'),
     {
       type: 'NameExpression',
       name: 'boolean'
     }, 'boolean');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: undefined) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('undefined'),
     {
       type: 'NameExpression',
       name: 'undefined'
     }, 'undefined');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: \"value\") { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('"value"'),
     {
       type: 'StringLiteral',
       name: 'value'
     }, 'StringLiteral');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: 1) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('1'),
     {
       type: 'NumberLiteral',
       name: '1'
     }, 'NumberLiteral');
 
-  t.deepEqual(flowDoctrine(toComment(
-      "/** add */function add(a: true) { }"
-    ).context.ast.node.params[0].typeAnnotation.typeAnnotation),
+  t.deepEqual(toDoctrineType('true'),
     {
       type: 'BooleanLiteral',
       name: true
     }, 'BooleanLiteral');
+
+  t.deepEqual(toDoctrineType('true'),
+    {
+      type: 'BooleanLiteral',
+      name: true
+    }, 'BooleanLiteral');
+
 
   t.end();
 });


### PR DESCRIPTION
This fixes issues with Flow tuples `[T, V]` and
Flow array types `T[]`.

Fixes #510