### PR TITLE
Fix github link generation for Node.js 6

### DIFF
--- a/lib/git/find_git.js
+++ b/lib/git/find_git.js
@@ -7,7 +7,7 @@ var fs = require('fs');
  * Given a full path to a single file, iterate upwards through the filesystem
  * to find a directory with a .git file indicating that it is a git repository
  * @param {string} filename any file within a repository
- * @returns {string} repository path
+ * @returns {string|undefined} repository path
  */
 function findGit(filename) {
   var paths = filename.split(path.sep);

--- a/lib/github.js
+++ b/lib/github.js
@@ -12,7 +12,8 @@ var getGithubURLPrefix = require('../lib/git/url_prefix');
  * @return {Object} comment with github inferred
  */
 module.exports = function (comment) {
-  var root = path.dirname(findGit(comment.context.file));
+  var repoPath = findGit(comment.context.file);
+  var root = repoPath ? path.dirname(repoPath) : '.';
   var urlPrefix = getGithubURLPrefix(root);
   var fileRelativePath = comment.context.file.replace(root + path.sep, '')
     .split(path.sep)


### PR DESCRIPTION
In Node.js 6 additional assertions was added in path module:
https://github.com/nodejs/node/pull/5348