### PR TITLE
Fix issue with watch and shallow

### DIFF
--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -86,11 +86,11 @@ function build(documentation, parsedArgs, callback) {
     }
   }
 
-  generator();
   if (buildOptions.watch) {
     var watcher = chokidar.watch(inputs);
     watcher.on('all', debounce(generator, 300));
   }
+  generator();
 
   function updateWatcher() {
     documentation.expandInputs(inputs, options, addNewFiles);
@@ -98,7 +98,7 @@ function build(documentation, parsedArgs, callback) {
 
   function addNewFiles(err, files) {
     watcher.add(files.map(function (data) {
-      return data.file;
+      return typeof data === 'string' ? data : data.file;
     }));
   }
 }

--- a/test/bin-watch-serve.js
+++ b/test/bin-watch-serve.js
@@ -73,13 +73,17 @@ test('--watch', options, function (t) {
     get('http://localhost:4001/', function (text) {
       t.ok(text.match(/apples/), 'sends an html index file');
       fs.writeFileSync(tmpFile, '/** a function */function bananas() {}');
-      setTimeout(function () {
+      function doGet() {
         get('http://localhost:4001/', function (text) {
-          t.ok(text.match(/bananas/), 'updates the file content');
-          docProcess.kill();
-          t.end();
+          if (text.match(/bananas/)) {
+            docProcess.kill();
+            t.end();
+          } else {
+            setTimeout(doGet, 100);
+          }
         });
-      }, 1000);
+      }
+      doGet();
     });
   });
 });
@@ -95,13 +99,17 @@ test('--watch', options, function (t) {
     get('http://localhost:4001/', function (text) {
       t.ok(text.match(/soup/), 'sends an html index file');
       fs.writeFileSync(b, '/** nuts */function nuts() {}');
-      setTimeout(function () {
+      function doGet() {
         get('http://localhost:4001/', function (text) {
-          t.ok(text.match(/nuts/), 'updates the file content even behind a require');
-          docProcess.kill();
-          t.end();
+          if (text.match(/nuts/)) {
+            docProcess.kill();
+            t.end();
+          } else {
+            setTimeout(doGet, 100);
+          }
         });
-      }, 1000);
+      }
+      doGet();
     });
   });
 });


### PR DESCRIPTION
When doing `--shallow --watch` we called `generator` (which
synchronously called `updateWatcher`/`addNewFiles`) but the watcher has
not been created yet. Instead create the watcher first before
`generator` is called.

Fixes #531