### PR TITLE
Improve theory behind anchors and links

### DIFF
--- a/default_theme/index._
+++ b/default_theme/index._
@@ -25,7 +25,7 @@
               <% docs.forEach(function(doc) { %>
                 <% var hasMembers = doc.members.static.length || doc.members.instance.length %>
                 <li><a
-                  href='#<%=slug(doc.namespace)%>'
+                  href='#<%- doc.namespace %>'
                   class="<% if (doc.kind === 'note') { %>h5 bold black caps<% } %><% if (hasMembers) { %> toggle-sibling<% } %>">
                   <%- doc.name %>
                   <% if (hasMembers) { %><span class='icon'>▸</span><% } %>
@@ -37,7 +37,7 @@
                     <li class='h5'><span>Static members</span></li>
                     <% doc.members.static.forEach(function(member) { %>
                       <li><a
-                        href='#<%=member.namespace%>'
+                        href='#<%- member.namespace %>'
                         class='regular pre-open'>
                         .<%- member.name %>
                       </a></li>

--- a/default_theme/index.js
+++ b/default_theme/index.js
@@ -6,7 +6,6 @@ var fs = require('fs'),
   vfs = require('vinyl-fs'),
   _ = require('lodash'),
   concat = require('concat-stream'),
-  GithubSlugger = require('github-slugger'),
   createFormatters = require('../').util.createFormatters,
   createLinkerStack = require('../').util.createLinkerStack,
   hljs = require('highlight.js');
@@ -15,8 +14,7 @@ module.exports = function (comments, options, callback) {
 
   var linkerStack = createLinkerStack(options)
     .namespaceResolver(comments, function (namespace) {
-      var slugger = new GithubSlugger();
-      return '#' + slugger.slug(namespace);
+      return '#' + namespace;
     });
 
   var formatters = createFormatters(linkerStack.link);
@@ -25,10 +23,6 @@ module.exports = function (comments, options, callback) {
 
   var sharedImports = {
     imports: {
-      slug: function (str) {
-        var slugger = new GithubSlugger();
-        return slugger.slug(str);
-      },
       shortSignature: function (section) {
         var prefix = '';
         if (section.kind === 'class') {
@@ -71,12 +65,12 @@ module.exports = function (comments, options, callback) {
       }
     }
   };
-  
+
   sharedImports.imports.renderSectionList =  _.template(fs.readFileSync(path.join(__dirname, 'section_list._'), 'utf8'), sharedImports);
   sharedImports.imports.renderSection = _.template(fs.readFileSync(path.join(__dirname, 'section._'), 'utf8'), sharedImports);
   sharedImports.imports.renderNote = _.template(fs.readFileSync(path.join(__dirname, 'note._'), 'utf8'), sharedImports);
 
-  var pageTemplate = _.template(fs.readFileSync(path.join(__dirname, 'index._'), 'utf8'),  sharedImports);
+  var pageTemplate = _.template(fs.readFileSync(path.join(__dirname, 'index._'), 'utf8'), sharedImports);
 
   // push assets into the pipeline as well.
   vfs.src([__dirname + '/assets/**'], { base: __dirname })

--- a/default_theme/section._
+++ b/default_theme/section._
@@ -2,7 +2,7 @@
 
   <% if (typeof nested === 'undefined') { %>
   <div class='clearfix'>
-    <h3 class='fl m0' id='<%- slug(section.namespace) %>'>
+    <h3 class='fl m0' id='<%- section.namespace %>'>
       <%- section.name %>
     </h3>
     <% if (section.context && section.context.github) { %>


### PR DESCRIPTION
Summary:

Right now documentation.js uses a blend of different approaches to
linking and needs a unified, tested system. The main change that this PR
makes so far is to avoid ever using 'slugifying' on namespaces in HTML
mode. Before we were doing so for headings, but not subheadings, and for
inline links but not links in the themes.

There's still research to be done here to figure out whether this is
robust enough - location hashes can include # and . characters, but can
they include everything else necessary in slugs? And does lodash's `<%-`
interpolation do enough to protect us from invalid HTML?

We'll still need to use slugifying for Markdown, since GitHub will
always create its own slugs.
- Fixes #525

TODO:
- [ ] Make anchors for sub-items linkable again. Main items have that nice
  hoverable link icon, but individual items don't.
