### PR TITLE
Format optional types with ? instead of []

### DIFF
--- a/default_theme/section._
+++ b/default_theme/section._
@@ -43,8 +43,8 @@
         <div class='space-bottom0'>
           <div>
             <span class='code bold'><%- param.name%></span> <code class='quiet'>(<%= formatType(param.type) %><% if (param.default) { %>
-            (default <code><%- param.default %></code>)
-            <% } %>)</code> <%= md(param.description, true) %>
+            = <code><%- param.default %></code><% } %>)</code>
+	    <%= md(param.description, true) %>
           </div>
           <% if (param.properties) { %>
           <table class='mt1 mb2 fixed-table h5 col-12'>

--- a/lib/output/util/format_type.js
+++ b/lib/output/util/format_type.js
@@ -73,7 +73,7 @@ function commaList(getHref, items, start, end, sep) {
  *
  * @param {Array<Object>} formatted remark AST of a type definition
  * @param {string} str postfix
- * @param {string} prefix string to put after the type comment
+ * @param {boolean} prefix string to put after the type comment
  * @returns {Array<Object>} suffixed and potentially prefixed type
  */
 function decorate(formatted, str, prefix) {
@@ -163,7 +163,7 @@ function formatType(getHref, node) {
     // lets the expression be omitted.
     return decorate(formatType(getHref, node.expression), '...', true);
   case Syntax.OptionalType:
-    return decorate(decorate(formatType(getHref, node.expression), '[', true), ']').concat(
+    return decorate(formatType(getHref, node.expression), '?', true).concat(
         node.default ? t('(default ' + node.default + ')') : []);
   case Syntax.NonNullableType:
     return decorate(formatType(getHref, node.expression), '!', node.prefix);

--- a/lib/output/util/format_type.js
+++ b/lib/output/util/format_type.js
@@ -163,7 +163,7 @@ function formatType(getHref, node) {
     // lets the expression be omitted.
     return decorate(formatType(getHref, node.expression), '...', true);
   case Syntax.OptionalType:
-    return decorate(formatType(getHref, node.expression), '?', true).concat(
+    return decorate(formatType(getHref, node.expression), '?').concat(
         node.default ? t('(default ' + node.default + ')') : []);
   case Syntax.NonNullableType:
     return decorate(formatType(getHref, node.expression), '!', node.prefix);

--- a/lib/output/util/format_type.js
+++ b/lib/output/util/format_type.js
@@ -163,12 +163,15 @@ function formatType(getHref, node) {
     // lets the expression be omitted.
     return decorate(formatType(getHref, node.expression), '...', true);
   case Syntax.OptionalType:
-    return decorate(formatType(getHref, node.expression), '?').concat(
-        node.default ? t('(default ' + node.default + ')') : []);
+    if (node.default) {
+      return decorate(formatType(getHref, node.expression), '?')
+        .concat(t('= ' + node.default));
+    }
+    return decorate(formatType(getHref, node.expression), '?');
   case Syntax.NonNullableType:
     return decorate(formatType(getHref, node.expression), '!', node.prefix);
   case Syntax.NullableType:
-    return decorate(formatType(getHref, node.expression), '?', node.prefix);
+    return decorate(formatType(getHref, node.expression), '?');
   case Syntax.StringLiteralType:
     return [u('inlineCode', JSON.stringify(node.value))];
   case Syntax.NumericLiteralType:

--- a/lib/output/util/formatters.js
+++ b/lib/output/util/formatters.js
@@ -29,7 +29,7 @@ module.exports = function (getHref) {
   formatters.parameter = function (param, short) {
     if (short) {
       return (param.type && param.type.type == Syntax.OptionalType) ?
-        '[' + param.name + ']' : param.name;
+        '?' + param.name : param.name;
     }
     return param.name + ': ' + formatters.type(param.type).replace(/\n/g, '');
   };

--- a/lib/output/util/formatters.js
+++ b/lib/output/util/formatters.js
@@ -28,8 +28,13 @@ module.exports = function (getHref) {
    */
   formatters.parameter = function (param, short) {
     if (short) {
-      return (param.type && param.type.type == Syntax.OptionalType) ?
-         param.name + '?' : param.name;
+      if (param.type && param.type.type == Syntax.OptionalType) {
+        if (param.default) {
+          return param.name + ' = ' + param.default;
+        }
+        return param.name + '?';
+      }
+      return param.name;
     }
     return param.name + ': ' + formatters.type(param.type).replace(/\n/g, '');
   };

--- a/lib/output/util/formatters.js
+++ b/lib/output/util/formatters.js
@@ -29,7 +29,7 @@ module.exports = function (getHref) {
   formatters.parameter = function (param, short) {
     if (short) {
       return (param.type && param.type.type == Syntax.OptionalType) ?
-        '?' + param.name : param.name;
+         param.name + '?' : param.name;
     }
     return param.name + ': ' + formatters.type(param.type).replace(/\n/g, '');
   };

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -240,7 +240,8 @@
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>foo</span> <code class='quiet'>(any)</code> 
+            <span class='code bold'>foo</span> <code class='quiet'>(any)</code>
+	    
           </div>
           
         </div>
@@ -293,14 +294,16 @@ This is a [link to something that does not exist]<a href="DoesNot">DoesNot</a></
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>other</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code> 
+            <span class='code bold'>other</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+	    
           </div>
           
         </div>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>also</span> <code class='quiet'>(any)</code> 
+            <span class='code bold'>also</span> <code class='quiet'>(any)</code>
+	    
           </div>
           
         </div>
@@ -366,7 +369,8 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>other</span> <code class='quiet'>(Weird)</code> 
+            <span class='code bold'>other</span> <code class='quiet'>(Weird)</code>
+	    
           </div>
           
         </div>
@@ -404,7 +408,7 @@ the referenced class type</p>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>isBuffer(buf, [size])</span>
+            <span class='code strong strong truncate'>isBuffer(buf, size = 0)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -415,7 +419,7 @@ the referenced class type</p>
   <p>This method takes a Buffer object that will be linked to nodejs.org</p>
 
 
-  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: [<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
 
   
 
@@ -431,16 +435,17 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>buf</span> <code class='quiet'>((<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code> 
+            <span class='code bold'>buf</span> <code class='quiet'>((<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
+	    
           </div>
           
         </div>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>size</span> <code class='quiet'>([<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>]
-            (default <code>0</code>)
-            )</code> size
+            <span class='code bold'>size</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?
+            = <code>0</code>)</code>
+	    size
 
           </div>
           
@@ -506,7 +511,8 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>buffers</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://nodejs.org/api/buffer.html">Buffer</a>>)</code> some buffers
+            <span class='code bold'>buffers</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://nodejs.org/api/buffer.html">Buffer</a>>)</code>
+	    some buffers
 
           </div>
           
@@ -721,7 +727,7 @@ k.isArrayOfBuffers();</pre>
   <p>A function with an options parameter</p>
 
 
-  <div class='pre p1 fill-light mt0'>withOptions(options: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, otherOptions: ?<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</div>
+  <div class='pre p1 fill-light mt0'>withOptions(options: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, otherOptions: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
 
   
 
@@ -737,7 +743,8 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code> 
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+	    
           </div>
           
           <table class='mt1 mb2 fixed-table h5 col-12'>
@@ -772,7 +779,8 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>otherOptions</span> <code class='quiet'>(?<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>)</code> 
+            <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
+	    
           </div>
           
         </div>
@@ -968,7 +976,8 @@ like a <a href="#klass">klass</a></p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>toys</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)</code> 
+            <span class='code bold'>toys</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)</code>
+	    
           </div>
           
         </div>

--- a/test/fixture/nearby_params.output.md
+++ b/test/fixture/nearby_params.output.md
@@ -9,6 +9,6 @@ Attempt to establish a cookie-based session in exchange for credentials.
 -   `credentials` **[object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `credentials.name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Login username. Also accepted as `username` or `email`.
     -   `credentials.password` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Login password
--   `callback` **\[[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)]** Gets passed `(err, { success:Boolean })`.
+-   `callback` **[function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)?** Gets passed `(err, { success:Boolean })`.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)** promise, to be resolved on success or rejected on failure

--- a/test/fixture/nearby_params.output.md.json
+++ b/test/fixture/nearby_params.output.md.json
@@ -339,10 +339,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function",
                       "type": "link",
@@ -355,7 +351,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },

--- a/test/fixture/nest_params.output.md
+++ b/test/fixture/nest_params.output.md
@@ -7,7 +7,7 @@
 -   `employees` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** The employees who are responsible for the project.
     -   `employees[].name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of an employee.
     -   `employees[].department` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The employee's department.
--   `type` **\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]** The employee's type. (optional, default `minion`)
+-   `type` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** The employee's type. (optional, default `minion`)
 
 # foo
 

--- a/test/fixture/nest_params.output.md.json
+++ b/test/fixture/nest_params.output.md.json
@@ -290,10 +290,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
@@ -306,7 +302,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },

--- a/test/fixture/optional-record-field-type.output.md
+++ b/test/fixture/optional-record-field-type.output.md
@@ -4,5 +4,5 @@
 
 **Properties**
 
--   `opt` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** 
+-   `opt` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 
 -   `req` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 

--- a/test/fixture/optional-record-field-type.output.md.json
+++ b/test/fixture/optional-record-field-type.output.md.json
@@ -46,10 +46,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
@@ -62,7 +58,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },

--- a/test/fixture/params.output.md
+++ b/test/fixture/params.output.md
@@ -30,7 +30,7 @@ This method has a type in the description and a default in the code
 
 **Parameters**
 
--   `x` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)](default 2)** 
+-   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?= 2** 
 
 # Foo
 
@@ -53,9 +53,9 @@ This tests  our support of optional parameters
 **Parameters**
 
 -   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** An IPv6 address string
--   `groups` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** How many octets to parse (optional, default `8`)
--   `third` **?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A third argument
--   `foo` **\[[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)]** to properly be parsed (optional, default `[1]`)
+-   `groups` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** How many octets to parse (optional, default `8`)
+-   `third` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** A third argument
+-   `foo` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** to properly be parsed (optional, default `[1]`)
 
 **Examples**
 
@@ -71,12 +71,12 @@ This tests our support of nested parameters
 
 **Parameters**
 
--   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** optional options
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** optional options
     -   `options.data` **([Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A GeoJSON data object or URL to it.
         The latter is preferable in case of large GeoJSON files.
-    -   `options.maxzoom` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Maximum zoom to preserve detail at. (optional, default `14`)
-    -   `options.buffer` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Tile buffer on each side.
-    -   `options.tolerance` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Simplification tolerance (higher means simpler).
+    -   `options.maxzoom` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Maximum zoom to preserve detail at. (optional, default `14`)
+    -   `options.buffer` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Tile buffer on each side.
+    -   `options.tolerance` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Simplification tolerance (higher means simpler).
 
 # myfunc
 
@@ -85,7 +85,7 @@ values specified in code.
 
 **Parameters**
 
--   `x` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)](default 123)** an argument
+-   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?= 123** an argument
 
 Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** some
 

--- a/test/fixture/params.output.md.json
+++ b/test/fixture/params.output.md.json
@@ -567,10 +567,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
@@ -583,11 +579,11 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     },
                     {
                       "type": "text",
-                      "value": "(default 2)"
+                      "value": "= 2"
                     }
                   ]
                 },
@@ -963,10 +959,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
@@ -979,7 +971,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },
@@ -1061,10 +1053,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "?"
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
@@ -1074,6 +1062,10 @@
                           "value": "number"
                         }
                       ]
+                    },
+                    {
+                      "type": "text",
+                      "value": "?"
                     }
                   ]
                 },
@@ -1138,10 +1130,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
@@ -1154,7 +1142,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },
@@ -1345,10 +1333,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
@@ -1361,7 +1345,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },
@@ -1528,10 +1512,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -1544,7 +1524,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1626,10 +1606,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -1642,7 +1618,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1707,10 +1683,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -1723,7 +1695,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1856,10 +1828,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
@@ -1872,11 +1840,11 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     },
                     {
                       "type": "text",
-                      "value": "(default 123)"
+                      "value": "= 123"
                     }
                   ]
                 },

--- a/test/fixture/sync/flow-types.output.md
+++ b/test/fixture/sync/flow-types.output.md
@@ -50,7 +50,7 @@ Very Important Transform
 **Parameters**
 
 -   `input` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
--   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]**  (optional, default `{}`)
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?**  (optional, default `{}`)
 
 Returns **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
@@ -60,7 +60,7 @@ Function with optional parameter.
 
 **Parameters**
 
--   `x` **\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]**  (optional, default `42`)
+-   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?**  (optional, default `42`)
 
 # objectParamFn
 

--- a/test/fixture/sync/flow-types.output.md.json
+++ b/test/fixture/sync/flow-types.output.md.json
@@ -1121,10 +1121,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
@@ -1137,7 +1133,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },
@@ -1273,10 +1269,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
@@ -1289,7 +1281,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },

--- a/test/fixture/sync/lots-of-options.output.md
+++ b/test/fixture/sync/lots-of-options.output.md
@@ -8,18 +8,18 @@ Global spectra deconvolution
 
 -   `x` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Independent variable
 -   `yIn` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>** Dependent variable
--   `options` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Options object
-    -   `options.sgOptions` **\[[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)]** Options object for Savitzky-Golay filter. See <https://github.com/mljs/savitzky-golay-generalized#options>
-    -   `options.minMaxRatio` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Threshold to determine if a given peak should be considered as a noise (optional, default `0.00025`)
-    -   `options.broadRatio` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** If `broadRatio` is higher than 0, then all the peaks which second derivative
+-   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options object
+    -   `options.sgOptions` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** Options object for Savitzky-Golay filter. See <https://github.com/mljs/savitzky-golay-generalized#options>
+    -   `options.minMaxRatio` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Threshold to determine if a given peak should be considered as a noise (optional, default `0.00025`)
+    -   `options.broadRatio` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** If `broadRatio` is higher than 0, then all the peaks which second derivative
         smaller than `broadRatio * maxAbsSecondDerivative` will be marked with the soft mask equal to true. (optional, default `0.00`)
-    -   `options.noiseLevel` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Noise threshold in spectrum units (optional, default `3`)
-    -   `options.maxCriteria` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Peaks are local maximum(true) or minimum(false) (optional, default `true`)
-    -   `options.smoothY` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Select the peak intensities from a smoothed version of the independent variables (optional, default `true`)
-    -   `options.realTopDetection` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Use a quadratic optimizations with the peak and its 3 closest neighbors
+    -   `options.noiseLevel` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Noise threshold in spectrum units (optional, default `3`)
+    -   `options.maxCriteria` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Peaks are local maximum(true) or minimum(false) (optional, default `true`)
+    -   `options.smoothY` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Select the peak intensities from a smoothed version of the independent variables (optional, default `true`)
+    -   `options.realTopDetection` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Use a quadratic optimizations with the peak and its 3 closest neighbors
         to determine the true x,y values of the peak? (optional, default `false`)
-    -   `options.heightFactor` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Factor to multiply the calculated height (usually 2) (optional, default `0`)
-    -   `options.boundaries` **\[[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)]** Return also the inflection points of the peaks (optional, default `false`)
-    -   `options.derivativeThreshold` **\[[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]** Filters based on the amplitude of the first derivative (optional, default `0`)
+    -   `options.heightFactor` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Factor to multiply the calculated height (usually 2) (optional, default `0`)
+    -   `options.boundaries` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?** Return also the inflection points of the peaks (optional, default `false`)
+    -   `options.derivativeThreshold` **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Filters based on the amplitude of the first derivative (optional, default `0`)
 
 Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** 

--- a/test/fixture/sync/lots-of-options.output.md.json
+++ b/test/fixture/sync/lots-of-options.output.md.json
@@ -265,10 +265,6 @@
                   "type": "strong",
                   "children": [
                     {
-                      "type": "text",
-                      "value": "["
-                    },
-                    {
                       "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
@@ -281,7 +277,7 @@
                     },
                     {
                       "type": "text",
-                      "value": "]"
+                      "value": "?"
                     }
                   ]
                 },
@@ -348,10 +344,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
                               "type": "link",
@@ -364,7 +356,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -466,10 +458,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -482,7 +470,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -564,10 +552,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -580,7 +564,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -734,10 +718,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -750,7 +730,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -832,10 +812,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "type": "link",
@@ -848,7 +824,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -930,10 +906,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "type": "link",
@@ -946,7 +918,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1028,10 +1000,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "type": "link",
@@ -1044,7 +1012,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1130,10 +1098,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -1146,7 +1110,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1228,10 +1192,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                               "type": "link",
@@ -1244,7 +1204,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },
@@ -1326,10 +1286,6 @@
                           "type": "strong",
                           "children": [
                             {
-                              "type": "text",
-                              "value": "["
-                            },
-                            {
                               "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
@@ -1342,7 +1298,7 @@
                             },
                             {
                               "type": "text",
-                              "value": "]"
+                              "value": "?"
                             }
                           ]
                         },

--- a/test/format_type.js
+++ b/test/format_type.js
@@ -38,7 +38,7 @@ test('formatType', function (t) {
     ['void', 'void'],
     ['function(a:b)', 'function (a: b)'],
     ['function(a):void', 'function (a): void'],
-    ['number=', '?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
+    ['number=', '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?'],
     ['...number', '...[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
     ['undefined', '[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)']
   ].forEach(function (example) {
@@ -49,7 +49,7 @@ test('formatType', function (t) {
 
   t.deepEqual(stringify(formatType(
     parse('@param {number} [a=1]', { sloppy: true }).tags[0].type)
-  ), '?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)', 'default');
+  ), '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?', 'default');
 
   t.deepEqual(stringify(_formatType(function (str) {
     return str.toUpperCase();

--- a/test/format_type.js
+++ b/test/format_type.js
@@ -38,7 +38,7 @@ test('formatType', function (t) {
     ['void', 'void'],
     ['function(a:b)', 'function (a: b)'],
     ['function(a):void', 'function (a): void'],
-    ['number=', '\\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]'],
+    ['number=', '?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
     ['...number', '...[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
     ['undefined', '[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)']
   ].forEach(function (example) {
@@ -49,7 +49,7 @@ test('formatType', function (t) {
 
   t.deepEqual(stringify(formatType(
     parse('@param {number} [a=1]', { sloppy: true }).tags[0].type)
-  ), '\\[[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)]', 'default');
+  ), '?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)', 'default');
 
   t.deepEqual(stringify(_formatType(function (str) {
     return str.toUpperCase();

--- a/test/format_type.js
+++ b/test/format_type.js
@@ -33,7 +33,7 @@ test('formatType', function (t) {
     ['{myNum: number, myObject}', '{myNum: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), myObject}'],
     ['[string,]', '\\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]'],
     ['number?', '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?'],
-    ['?number', '?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
+    ['number', '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
     ['?', '?'],
     ['void', 'void'],
     ['function(a:b)', 'function (a: b)'],

--- a/test/lib/output/util/formatters.js
+++ b/test/lib/output/util/formatters.js
@@ -5,7 +5,7 @@ test('formatters.parameters -- long form', function (t) {
   t.deepEqual(formatters.parameters({}), '()');
   t.deepEqual(formatters.parameters({ params: [] }), '()');
   t.deepEqual(formatters.parameters({ params: [{ name: 'foo' }] }), '(foo: any)');
-  t.deepEqual(formatters.parameters({ params: [{ name: 'foo', type: { type: 'OptionalType' } }] }), '(foo: [any])');
+  t.deepEqual(formatters.parameters({ params: [{ name: 'foo', type: { type: 'OptionalType' } }] }), '(foo: any?)');
   t.done();
 });
 
@@ -15,7 +15,21 @@ test('formatters.parameters -- short form', function (t) {
   t.deepEqual(formatters.parameters({ params: [{ name: 'foo' }] }, true), '(foo)');
   t.deepEqual(formatters.parameters({
     params: [{ name: 'foo', type: { type: 'OptionalType' } }]
-  }, true), '([foo])');
+  }, true), '(foo?)');
+  t.deepEqual(formatters.parameters({
+    params: [{
+      title: 'param',
+      description: 'param',
+      type: {
+        type: 'OptionalType',
+        expression: {
+          type: 'NameExpression',
+          name: 'number'
+        }},
+      name: 'bar',
+      default: '1'
+    }]
+  }, true), '(bar = 1)');
   t.done();
 });
 


### PR DESCRIPTION
Fixes #509

Formats optionals with `?` instead of `[]`, to avoid confusion with array types.

![2016-09-09 at 11 18 am](https://cloud.githubusercontent.com/assets/32314/18394416/8e57dee4-767f-11e6-8906-f9948dfe3c8c.png)
