### PR TITLE
Membership inference improvements

### DIFF
--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -34,7 +34,7 @@ function findLendsIdentifiers(node) {
 /**
  * Extract and return the identifiers for expressions of type this.foo
  *
- * @param {NodePath} path AssignmentExression, MemberExpression, or Identifier
+ * @param {NodePath} path AssignmentExpression, MemberExpression, or Identifier
  * @returns {Array<string>} identifiers
  * @private
  */
@@ -49,7 +49,7 @@ function extractThis(path) {
      * @private
      */
     ThisExpression: function (path) {
-      let scope = path.scope;
+      var scope = path.scope;
 
       while (n.isBlockStatement(scope.block)) {
         scope = scope.parent;

--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -122,19 +122,20 @@ function countModuleIdentifiers(comment, identifiers) {
  */
 function normalizeMemberof(comment) {
   var memberof = comment.memberof;
-  var index = memberof.lastIndexOf('.');
 
-  if (index !== -1 && memberof.slice(index + 1) === 'prototype') {
-    comment.memberof = memberof.slice(0, index);
+  var isPrototype = /.prototype$/;
+
+  if (memberof.match(isPrototype) !== null) {
+    comment.memberof = memberof.replace(isPrototype, '');
     comment.scope = 'instance';
 
     return comment;
   }
 
-  var last = memberof.length - 1;
+  var isInstanceMember = /#$/;
 
-  if (memberof[last] === '#') {
-    comment.memberof = memberof.slice(0, last);
+  if (memberof.match(isInstanceMember) !== null) {
+    comment.memberof = memberof.replace(isInstanceMember, '');
     comment.scope = 'instance';
   }
 

--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -32,6 +32,45 @@ function findLendsIdentifiers(node) {
 }
 
 /**
+ * Extract and return the identifiers for expressions of type this.foo
+ *
+ * @param {NodePath} path AssignmentExression, MemberExpression, or Identifier
+ * @returns {Array<string>} identifiers
+ * @private
+ */
+function extractThis(path) {
+  var identifiers = [];
+
+  path.traverse({
+    /**
+     * Add the resolved identifier of this in a path to the identifiers array
+     * @param {Object} path ast path
+     * @returns {undefined} has side-effects
+     * @private
+     */
+    ThisExpression: function (path) {
+      let scope = path.scope;
+
+      while (n.isBlockStatement(scope.block)) {
+        scope = scope.parent;
+      }
+
+      if (n.isClassMethod(scope.block)) {
+        identifiers.push(scope.path.parentPath.parentPath.node.id.name, 'prototype');
+      }
+
+      if (n.isFunctionDeclaration(scope.block) ||
+          n.isFunctionExpression(scope.block)) {
+        identifiers.push(scope.block.id.name , 'prototype');
+      }
+    }
+  });
+
+  return identifiers;
+}
+
+
+/**
  * Extract and return the chain of identifiers from the left hand side of expressions
  * of the forms `Foo = ...`, `Foo.bar = ...`, `Foo.bar.baz = ...`, etc.
  *
@@ -202,7 +241,10 @@ module.exports = function () {
     // Foo.prototype.bar = ...;
     // Foo.bar.baz = ...;
     if (n.isMemberExpression(path.node)) {
-      identifiers = extractIdentifiers(path);
+      identifiers = [].concat(
+        extractThis(path),
+        extractIdentifiers(path)
+      );
       if (identifiers.length >= 2) {
         inferMembershipFromIdentifiers(comment, identifiers.slice(0, -1));
       }

--- a/lib/infer/membership.js
+++ b/lib/infer/membership.js
@@ -77,6 +77,32 @@ function countModuleIdentifiers(comment, identifiers) {
 }
 
 /**
+ * Returns the comment object after normalizing Foo.prototype and Foo# expressions
+ * @param {Object} comment parsed comment
+ * @returns {Object} the normalized comment
+ */
+function normalizeMemberof(comment) {
+  var memberof = comment.memberof;
+  var index = memberof.lastIndexOf('.');
+
+  if (index !== -1 && memberof.slice(index + 1) === 'prototype') {
+    comment.memberof = memberof.slice(0, index);
+    comment.scope = 'instance';
+
+    return comment;
+  }
+
+  var last = memberof.length - 1;
+
+  if (memberof[last] === '#') {
+    comment.memberof = memberof.slice(0, last);
+    comment.scope = 'instance';
+  }
+
+  return comment;
+}
+
+/**
  * Uses code structure to infer `memberof`, `instance`, and `static`
  * tags from the placement of JSDoc
  * annotations within a file
@@ -147,7 +173,7 @@ module.exports = function () {
     }
 
     if (comment.memberof) {
-      return comment;
+      return normalizeMemberof(comment);
     }
 
     if (!comment.context.ast) {

--- a/test/lib/infer/membership.js
+++ b/test/lib/infer/membership.js
@@ -146,6 +146,44 @@ test('inferMembership - explicit', function (t) {
   }, 'variable object assignment, function');
 
   t.deepEqual(pick(evaluate(function () {
+    function Foo() {
+      {
+        /** */
+        this.bar = 0;
+      }
+    }
+  })[0], ['memberof', 'scope']), {
+    memberof: 'Foo',
+    scope: 'instance'
+  }, 'constructor function declaration assignment');
+
+  t.deepEqual(pick(evaluate(function () {
+    var Foo = function Bar() {
+      {
+        /** */
+        this.baz = 0;
+      }
+    };
+  })[0], ['memberof', 'scope']), {
+    memberof: 'Bar',
+    scope: 'instance'
+  }, 'constructor function expression assignment');
+
+  t.deepEqual(pick(evaluate(function () {
+    class Foo {
+      constructor() {
+        {
+          /** */
+          this.bar = 0;
+        }
+      }
+    }
+  })[0], ['memberof', 'scope']), {
+    memberof: 'Foo',
+    scope: 'instance'
+  }, 'constructor assignment');
+
+  t.deepEqual(pick(evaluate(function () {
     /** Test */
     module.exports = function () {};
   })[0], ['memberof', 'scope']), {

--- a/test/lib/infer/membership.js
+++ b/test/lib/infer/membership.js
@@ -38,7 +38,29 @@ test('inferMembership - explicit', function (t) {
   })[0], ['memberof', 'scope']), {
     memberof: 'Bar',
     scope: 'static'
-  }, 'explicit');
+  }, 'explicit, static');
+
+  t.deepEqual(pick(evaluate(function () {
+    /**
+     * Test
+     * @memberof Bar#
+     */
+    Foo.bar = 0;
+  })[0], ['memberof', 'scope']), {
+    memberof: 'Bar',
+    scope: 'instance'
+  }, 'explicit, instance');
+
+  t.deepEqual(pick(evaluate(function () {
+    /**
+     * Test
+     * @memberof Bar.prototype
+     */
+    Foo.bar = 0;
+  })[0], ['memberof', 'scope']), {
+    memberof: 'Bar',
+    scope: 'instance'
+  }, 'explicit, prototype');
 
   t.deepEqual(pick(evaluate(function () {
     /** Test */


### PR DESCRIPTION
Added normalization of `@memberof Foo#` and `@memberof Foo.prototype`
Added membership inference for `this.foo` inside constructor functions and class members