### PR TITLE
Show GitHub link for nested elements in default theme

### DIFF
--- a/default_theme/section._
+++ b/default_theme/section._
@@ -1,10 +1,12 @@
 <section class='p2 mb2 clearfix bg-white minishadow'>
 
-  <% if (typeof nested === 'undefined') { %>
+  <% if (typeof nested === 'undefined' || (section.context && section.context.github)) { %>
   <div class='clearfix'>
+    <% if (typeof nested === 'undefined') { %>
     <h3 class='fl m0' id='<%- slug(section.namespace) %>'>
       <%- section.name %>
     </h3>
+    <% } %>
     <% if (section.context && section.context.github) { %>
       <a class='fr fill-darken0 round round pad1x quiet h5' href='<%= section.context.github %>'>
       <span><%= section.context.path %></span>

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -195,9 +195,11 @@
 
   
   <div class='clearfix'>
+    
     <h3 class='fl m0' id='klass'>
       Klass
     </h3>
+    
     
   </div>
   
@@ -800,9 +802,11 @@ k.isArrayOfBuffers();</pre>
 
   
   <div class='clearfix'>
+    
     <h3 class='fl m0' id='bar'>
       bar
     </h3>
+    
     
   </div>
   
@@ -854,9 +858,11 @@ like a <a href="#klass">klass</a></p>
 
   
   <div class='clearfix'>
+    
     <h3 class='fl m0' id='bar'>
       bar
     </h3>
+    
     
   </div>
   
@@ -918,9 +924,11 @@ like a <a href="#klass">klass</a></p>
 
   
   <div class='clearfix'>
+    
     <h3 class='fl m0' id='bar'>
       bar
     </h3>
+    
     
   </div>
   
@@ -972,9 +980,11 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
 
   
   <div class='clearfix'>
+    
     <h3 class='fl m0' id='foo'>
       Foo
     </h3>
+    
     
   </div>
   
@@ -1067,9 +1077,11 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
 
   
   <div class='clearfix'>
+    
     <h3 class='fl m0' id='customstreams'>
       customStreams
     </h3>
+    
     
   </div>
   


### PR DESCRIPTION
Ref: https://github.com/documentationjs/documentation/issues/469

This adds a link to all the methods of class. It is currently only generated for the whole class itself.