### PR TITLE
Fix linkerStack resolution order

### DIFF
--- a/lib/output/util/linker_stack.js
+++ b/lib/output/util/linker_stack.js
@@ -43,7 +43,7 @@ function LinkerStack(config) {
   this.stack = [];
 
   if (config.defaultGlobals !== false) {
-    this.stack.push(function (namespace) {
+    this.stack.unshift(function (namespace) {
       if (namespace) {
         return globalsDocs.getDoc(namespace, config.defaultGlobalsEnvs);
       }
@@ -51,7 +51,7 @@ function LinkerStack(config) {
   }
 
   if (config.paths) {
-    this.stack.push(pathsLinker(config.paths));
+    this.stack.unshift(pathsLinker(config.paths));
   }
 
   this.link = this.link.bind(this);
@@ -84,7 +84,7 @@ LinkerStack.prototype.namespaceResolver = function (comments, resolver) {
   walk(comments, function (comment) {
     namespaces[comment.namespace] = true;
   });
-  this.stack.push(function (namespace) {
+  this.stack.unshift(function (namespace) {
     if (namespaces[namespace] === true) {
       return resolver(namespace);
     }

--- a/test/linker.js
+++ b/test/linker.js
@@ -17,5 +17,31 @@ test('linkerStack', function (t) {
     'http://geojson.org/geojson-spec.html#point',
     'Custom hardcoded path for a GeoJSON type');
 
+
+  t.equal(createLinkerStack({
+    paths: {
+      Image: 'http://custom.com/'
+    }
+  }).link('Image'),
+    'http://custom.com/',
+    'Prefers config link to native.');
+
+
+  var linker = createLinkerStack({
+    paths: {
+      Image: 'http://custom.com/'
+    }
+  });
+
+  linker.namespaceResolver([{
+    namespace: 'Image',
+  }], function (namespace) {
+    return '#' + namespace;
+  });
+
+  t.equal(linker.link('Image'),
+    '#Image',
+    'Prefers local link over all.');
+
   t.end();
 });


### PR DESCRIPTION
Fixes #563 

Question: should custom links in configuration files win out over links to namespaces in documentation? With this PR, they would _not_ - resolution order would be:

1. Namespace
2. Configuration
3. Globals (MDN)