### PR TITLE
Resolve imports without extension

### DIFF
--- a/lib/extractors/exported.js
+++ b/lib/extractors/exported.js
@@ -28,7 +28,8 @@ function walkExported(ast, data, addComment) {
 
   function getComments(data, path) {
     if (!hasJSDocComment(path)) {
-      return [addBlankComment(data, path, path.node)];
+      var added = addBlankComment(data, path, path.node);
+      return added ? [added] : [];
     }
     return path.node.leadingComments.filter(isJSDocComment).map(function (comment) {
       return addComment(data, comment.value, comment.loc, path, path.node.loc, true);
@@ -136,7 +137,12 @@ function traverseExportedSubtree(path, data, addComments, overrideName) {
   }
 }
 
-function getCachedData(dataCache, path) {
+function getCachedData(dataCache, filePath) {
+  var path = filePath;
+  if (!nodePath.extname(path)) {
+    path = require.resolve(path);
+  }
+
   var value = dataCache[path];
   if (!value) {
     var input = fs.readFileSync(path, 'utf-8');

--- a/lib/parsers/javascript.js
+++ b/lib/parsers/javascript.js
@@ -70,8 +70,13 @@ function _addComment(visited, data, commentValue, commentLoc, path, nodeLoc, inc
       });
 
       if (path.parentPath && path.parentPath.node) {
-        context.code = data.source.substring
-          .apply(data.source, path.parentPath.node.range);
+        var parentNode = path.parentPath.node;
+        if (parentNode.range) {
+          context.code = data.source.substring
+            .apply(data.source, parentNode.range);
+        } else {
+          context.code = data.source.substring(parentNode.start, parentNode.end);
+        }
       }
     }
     return parse(commentValue, commentLoc, context);

--- a/lib/parsers/javascript.js
+++ b/lib/parsers/javascript.js
@@ -71,12 +71,7 @@ function _addComment(visited, data, commentValue, commentLoc, path, nodeLoc, inc
 
       if (path.parentPath && path.parentPath.node) {
         var parentNode = path.parentPath.node;
-        if (parentNode.range) {
-          context.code = data.source.substring
-            .apply(data.source, parentNode.range);
-        } else {
-          context.code = data.source.substring(parentNode.start, parentNode.end);
-        }
+        context.code = data.source.substring(parentNode.start, parentNode.end);
       }
     }
     return parse(commentValue, commentLoc, context);

--- a/test/fixture/document-exported.input.js
+++ b/test/fixture/document-exported.input.js
@@ -47,7 +47,7 @@ var notExportedObject =  {
   func: function() {},
 };
 
-export {x, y3 as y4} from './document-exported/x.js';
+export {x, y3 as y4} from './document-exported/x';
 export z from  './document-exported/z.js';
 export y2Default from  './document-exported/y.js';
 


### PR DESCRIPTION
In my use case, I have a project where imports are written without a file extension, i.e.

```js
import { foo } from './foo'; // => foo.js or foo/index.js
```

This PR uses `require.resolve` to figure out the actual file name if no extension was specified.
Most probably, a more advanced resolution would be better but this should be good enough and avoids some confusion.

Additionally, I have fixed a few problems I ran into.