### PR TITLE
Pick up comments on VariableDeclarations

### DIFF
--- a/lib/extractors/exported.js
+++ b/lib/extractors/exported.js
@@ -27,11 +27,21 @@ function walkExported(ast, data, addComment) {
   }
 
   function getComments(data, path) {
-    if (!hasJSDocComment(path)) {
+    var comments = (path.node.leadingComments || []).filter(isJSDocComment);
+
+    if (!comments.length) {
+      // If this is the first declarator we check for comments on the VariableDeclaration.
+      if (t.isVariableDeclarator(path) && path.parentPath.get('declarations')[0] === path) {
+        return getComments(data, path.parentPath);
+      }
+    }
+
+    if (!comments.length) {
       var added = addBlankComment(data, path, path.node);
       return added ? [added] : [];
     }
-    return path.node.leadingComments.filter(isJSDocComment).map(function (comment) {
+
+    return comments.map(function (comment) {
       return addComment(data, comment.value, comment.loc, path, path.node.loc, true);
     }).filter(Boolean);
   }
@@ -104,10 +114,6 @@ function walkExported(ast, data, addComment) {
   });
 
   return newResults;
-}
-
-function hasJSDocComment(path) {
-  return path.node.leadingComments && path.node.leadingComments.some(isJSDocComment);
 }
 
 function traverseExportedSubtree(path, data, addComments, overrideName) {

--- a/lib/extractors/exported.js
+++ b/lib/extractors/exported.js
@@ -34,9 +34,7 @@ function walkExported(ast, data, addComment) {
       if (t.isVariableDeclarator(path) && path.parentPath.get('declarations')[0] === path) {
         return getComments(data, path.parentPath);
       }
-    }
 
-    if (!comments.length) {
       var added = addBlankComment(data, path, path.node);
       return added ? [added] : [];
     }

--- a/test/fixture/document-exported.input.js
+++ b/test/fixture/document-exported.input.js
@@ -66,14 +66,16 @@ export type {T5} from './document-exported/x.js';
 
 export var f4 = function(x: X) {}
 
-var f5 = function(y: Y) {}
+
 export {f5};
 
 export var o1 = {
   om1() {}
 }
 
-var o2 = {
-  om2() {}
-}
+/** f5 comment */
+var f5 = function(y: Y) {},
+  o2 = {
+    om2() {}
+  };
 export {o2};

--- a/test/fixture/document-exported.output.json
+++ b/test/fixture/document-exported.output.json
@@ -1189,55 +1189,6 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 69,
-        "column": 4
-      },
-      "end": {
-        "line": 69,
-        "column": 26
-      }
-    },
-    "context": {
-      "loc": {
-        "start": {
-          "line": 69,
-          "column": 4
-        },
-        "end": {
-          "line": 69,
-          "column": 26
-        }
-      }
-    },
-    "errors": [],
-    "name": "f5",
-    "params": [
-      {
-        "title": "param",
-        "name": "y",
-        "lineNumber": 69,
-        "type": {
-          "type": "NameExpression",
-          "name": "Y"
-        }
-      }
-    ],
-    "members": {
-      "instance": [],
-      "static": []
-    },
-    "path": [
-      {
-        "name": "f5"
-      }
-    ],
-    "namespace": "f5"
-  },
-  {
-    "description": "",
-    "tags": [],
-    "loc": {
-      "start": {
         "line": 72,
         "column": 0
       },
@@ -1312,27 +1263,129 @@
     "namespace": "om1"
   },
   {
-    "description": "",
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "f5 comment",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 11,
+                  "offset": 10
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 11,
+              "offset": 10
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 11,
+          "offset": 10
+        }
+      }
+    },
     "tags": [],
     "loc": {
       "start": {
         "line": 76,
-        "column": 4
+        "column": 0
       },
       "end": {
-        "line": 78,
-        "column": 1
+        "line": 76,
+        "column": 17
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 76,
-          "column": 4
+          "line": 77,
+          "column": 0
         },
         "end": {
+          "line": 80,
+          "column": 4
+        }
+      }
+    },
+    "errors": [],
+    "name": "f5",
+    "kind": "function",
+    "params": [
+      {
+        "title": "param",
+        "name": "y",
+        "lineNumber": 77,
+        "type": {
+          "type": "NameExpression",
+          "name": "Y"
+        }
+      }
+    ],
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "f5",
+        "kind": "function"
+      }
+    ],
+    "namespace": "f5"
+  },
+  {
+    "description": "",
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 78,
+        "column": 2
+      },
+      "end": {
+        "line": 80,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
           "line": 78,
-          "column": 1
+          "column": 2
+        },
+        "end": {
+          "line": 80,
+          "column": 3
         }
       }
     },
@@ -1354,23 +1407,23 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 77,
-        "column": 2
+        "line": 79,
+        "column": 4
       },
       "end": {
-        "line": 77,
-        "column": 10
+        "line": 79,
+        "column": 12
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 77,
-          "column": 2
+          "line": 79,
+          "column": 4
         },
         "end": {
-          "line": 77,
-          "column": 10
+          "line": 79,
+          "column": 12
         }
       }
     },

--- a/test/fixture/document-exported.output.md
+++ b/test/fixture/document-exported.output.md
@@ -78,15 +78,17 @@ Returns **void**
 
 -   `x` **X** 
 
+# o1
+
+# om1
+
 # f5
+
+f5 comment
 
 **Parameters**
 
 -   `y` **Y** 
-
-# o1
-
-# om1
 
 # o2
 

--- a/test/fixture/document-exported.output.md.json
+++ b/test/fixture/document-exported.output.md.json
@@ -565,9 +565,64 @@
       "children": [
         {
           "type": "text",
+          "value": "o1"
+        }
+      ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "om1"
+        }
+      ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
           "value": "f5"
         }
       ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "f5 comment",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 11,
+              "offset": 10
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 11,
+          "offset": 10
+        },
+        "indent": []
+      }
     },
     {
       "type": "strong",
@@ -612,26 +667,6 @@
               ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "depth": 1,
-      "type": "heading",
-      "children": [
-        {
-          "type": "text",
-          "value": "o1"
-        }
-      ]
-    },
-    {
-      "depth": 1,
-      "type": "heading",
-      "children": [
-        {
-          "type": "text",
-          "value": "om1"
         }
       ]
     },


### PR DESCRIPTION
When we find the binding for an export we get the VariableDeclarator.
It is common for people to write their JSDoc comment on the parent
VariableDeclaration so we check that in case there is no comment on the
declarator.

Fixes #570