### PR TITLE
Fix ReferenceError in default theme

### DIFF
--- a/default_theme/section._
+++ b/default_theme/section._
@@ -90,7 +90,7 @@
           <% if (property.properties) { %>
             <ul>
               <% property.properties.forEach(function(property) { %>
-                <li><code><%- name%></code> <%= formatType(property.type) %>
+                <li><code><%- property.name %></code> <%= formatType(property.type) %>
                   <% if (property.default) { %>
                     (default <code><%- property.default %></code>)
                   <% } %>

--- a/test/fixture/html/nested.input.js
+++ b/test/fixture/html/nested.input.js
@@ -30,6 +30,15 @@ Klass.prototype.withOptions = function (options, otherOptions) {
 };
 
 /**
+ * @typedef CustomError
+ * @name CustomError
+ * @description a typedef with nested properties
+ * @property {object} error An error
+ * @property {string} error.code The error's code
+ * @property {string} error.description The error's description
+ */
+
+/**
  * Decide whether an object is a Klass instance
  * This is a [klasssic]{@link Klass}
  * This is a [link to something that does not exist]{@link DoesNot}

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -99,6 +99,16 @@
               
                 
                 <li><a
+                  href='#customerror'
+                  class="">
+                  CustomError
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
                   href='#bar'
                   class="">
                   bar
@@ -789,6 +799,78 @@ k.isArrayOfBuffers();</pre>
     </div>
   
 </div>
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='customerror'>
+      CustomError
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>a typedef with nested properties</p>
+
+
+  <div class='pre p1 fill-light mt0'>CustomError</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>error</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>)</code>
+          : An error
+
+          
+            <ul>
+              
+                <li><code>error.code</code> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+                  
+                  <p>The error's code</p>
+</li>
+              
+                <li><code>error.description</code> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+                  
+                  <p>The error's description</p>
+</li>
+              
+            </ul>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
 
   
 


### PR DESCRIPTION
There does not seem to be any test suite for the theme. This fixes an uncaught exception when you are using the html output with the default theme and your code has nested attributes.

i.e.
```
$ documentation build -f html -o docs
lodash.templateSources[1]:136
__e( name) +
     ^

ReferenceError: name is not defined
    at eval (lodash.templateSources[1]:136:6)
    at Array.forEach (native)
    at eval (lodash.templateSources[1]:134:22)
    at Array.forEach (native)
    at eval (lodash.templateSources[1]:113:21)
    at eval (lodash.templateSources[3]:84:11)
    at Array.forEach (native)
    at eval (lodash.templateSources[3]:80:7)
    at /Users/cmcelligott/.nvm/versions/node/v6.9.1/lib/node_modules/documentation/default_theme/index.js:86:30
    at ConcatStream.<anonymous> (/Users/cmcelligott/.nvm/versions/node/v6.9.1/lib/node_modules/documentation/node_modules/concat-stream/index.js:36:43)
```

Closes #559.