### PR TITLE
Add more usage examples. Fixes #526

### DIFF
--- a/bin/documentation.js
+++ b/bin/documentation.js
@@ -15,6 +15,28 @@ var argv = yargs
   .version(function () {
     return require('../package').version;
   })
+  .usage('Usage:\n\n' +
+    '# generate markdown docs for index.js and files it references\n' +
+    '$0 build index.js -f md\n\n' +
+
+    '# generate html docs for all files in src\n' +
+    '$0 build src/** -f html -o docs\n\n' +
+
+    '# document index.js, ignoring any files it requires or imports\n' +
+    '$0 build index.js -f md --shallow\n\n' +
+
+    '# build, serve, and live-update html docs for app.js\n' +
+    '$0 serve app.js\n\n' +
+
+    '# validate JSDoc syntax in util.js\n' +
+    '$0 lint util.js\n\n' +
+
+    '# update the API section of README.md with docs from index.js\n' +
+    '$0 readme index.js --section=API\n\n' +
+
+    '# build docs for all values exported by index.js\n' +
+    '$0 build --document-exported index.js'
+  )
   .recommendCommands()
   .help()
   .argv;


### PR DESCRIPTION
cc @arv for the review. Unfortunately I'm not seeing any way `yargs` will let us show usage examples for commands (in `documentation build --help` for instance), but this is a first step. And if this seems like a step in the right direction, we can copy/paste these examples elsewhere, like in the README.