### PR TITLE
Highlight all Markdown, not just examples. Fixes #610

### DIFF
--- a/lib/output/highlighter.js
+++ b/lib/output/highlighter.js
@@ -1,0 +1,22 @@
+var visit = require('unist-util-visit');
+var hljs = require('highlight.js');
+
+/**
+ * Adapted from remark-highlight.js
+ * https://github.com/ben-eb/remark-highlight.js
+ * @param {Object} node AST node
+ * @returns {undefined} modifies the node by reference
+ * @private
+ */
+function visitor(node) {
+  if (node.lang) {
+    node.type = 'html';
+    node.value = '<pre class=\'hljs\'>' +
+      hljs.highlightAuto(node.value, [node.lang]).value + '</pre>';
+  }
+}
+
+module.exports = function (ast) {
+  visit(ast, 'code', visitor);
+  return ast;
+};

--- a/lib/output/util/formatters.js
+++ b/lib/output/util/formatters.js
@@ -3,6 +3,7 @@ var remark = require('remark'),
   Syntax = require('doctrine').Syntax,
   u = require('unist-builder'),
   _rerouteLinks = require('./reroute_links'),
+  highlighter = require('../highlighter'),
   formatType = require('./format_type');
 
 /**
@@ -46,7 +47,9 @@ module.exports = function (getHref) {
    */
   formatters.markdown = function (ast) {
     if (ast) {
-      return remark().use(html).stringify(rerouteLinks(ast));
+      return remark()
+        .use(html)
+        .stringify(highlighter(rerouteLinks(ast)));
     }
   };
 

--- a/lib/parse_markdown.js
+++ b/lib/parse_markdown.js
@@ -1,7 +1,6 @@
 var remark = require('remark');
 var inlineTokenizer = require('./inline_tokenizer');
 
-
 /**
  * Parse a string of Markdown into a Remark
  * abstract syntax tree.

--- a/lib/parse_markdown.js
+++ b/lib/parse_markdown.js
@@ -1,6 +1,7 @@
 var remark = require('remark');
 var inlineTokenizer = require('./inline_tokenizer');
 
+
 /**
  * Parse a string of Markdown into a Remark
  * abstract syntax tree.

--- a/test/bin.js
+++ b/test/bin.js
@@ -189,7 +189,6 @@ test('--config', options, function (t) {
   var expectedOutputPath = path.join(__dirname, 'fixture/html/nested.config-output.html');
   documentation(['build -c fixture/html/documentation.yml -f html fixture/html/nested.input.js -o ' +
     dst], function (err) {
-      console.log(err);
     t.notOk(err);
     var output = fs.readFileSync(outputIndex, 'utf8');
     if (process.env.UPDATE) {

--- a/test/bin.js
+++ b/test/bin.js
@@ -182,6 +182,25 @@ test('invalid arguments', function (group) {
   group.end();
 });
 
+test('--config', options, function (t) {
+  var dst = path.join(os.tmpdir(), (Date.now() + Math.random()).toString());
+  fs.mkdirSync(dst);
+  var outputIndex = path.join(dst, 'index.html');
+  var expectedOutputPath = path.join(__dirname, 'fixture/html/nested.config-output.html');
+  documentation(['build -c fixture/html/documentation.yml -f html fixture/html/nested.input.js -o ' +
+    dst], function (err) {
+      console.log(err);
+    t.notOk(err);
+    var output = fs.readFileSync(outputIndex, 'utf8');
+    if (process.env.UPDATE) {
+      fs.writeFileSync(expectedOutputPath, output);
+    }
+    var expectedOutput = fs.readFileSync(expectedOutputPath, 'utf8');
+    t.equal(expectedOutput, output, 'generates correct output');
+    t.end();
+  }, false);
+});
+
 test('--version', options, function (t) {
   documentation(['--version'], {}, function (err, output) {
     t.ok(output, 'outputs version');

--- a/test/fixture/html/documentation.yml
+++ b/test/fixture/html/documentation.yml
@@ -1,0 +1,22 @@
+toc:
+  - name: Highlighted section
+    description: |
+      The public key is a base64 encoded string of a protobuf containing an RSA DER
+      buffer. This uses a node buffer to pass the base64 encoded public key protobuf
+      to the multihash for ID generation.
+
+      ```js
+      var PeerId = require('peer-id')
+
+      PeerId.create({ bits: 1024 }, (err, id) => {
+        console.log(JSON.stringify(id.toJSON(), null, 2)
+      })
+      ```
+
+      ```
+      {
+        "id": "Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi",
+        "privKey": "CAAS4AQwggJcAgEAAoGBAMBgbIqyOL26oV3nGPBYrdpbv..",
+        "pubKey": "CAASogEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMBgbIqyOL26oV3nGPBYrdpbvzCY..."
+      }
+      ```

--- a/test/fixture/html/nested.config-output.html
+++ b/test/fixture/html/nested.config-output.html
@@ -1,0 +1,1307 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset='utf-8' />
+  <title>  | Documentation</title>
+  <meta name='viewport' content='width=device-width,initial-scale=1'>
+  <link href='assets/bass.css' type='text/css' rel='stylesheet' />
+  <link href='assets/style.css' type='text/css' rel='stylesheet' />
+  <link href='assets/github.css' type='text/css' rel='stylesheet' />
+</head>
+<body class='documentation'>
+  <div class='max-width-4 mx-auto'>
+    <div class='clearfix md-mxn2'>
+      <div class='fixed xs-hide fix-3 overflow-auto max-height-100'>
+        <div class='py1 px2'>
+          <h3 class='mb0 no-anchor'></h3>
+          <div class='mb1'><code></code></div>
+          <input
+            placeholder='Filter'
+            id='filter-input'
+            class='col12 block input'
+            type='text' />
+          <div id='toc'>
+            <ul class='list-reset h5 py1-ul'>
+              
+                
+                <li><a
+                  href='#highlighted-section'
+                  class="h5 bold black caps">
+                  Highlighted section
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#klass'
+                  class=" toggle-sibling">
+                  Klass
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  <ul class='list-reset py1-ul pl1'>
+                    <li class='h5'><span>Static members</span></li>
+                    
+                      <li><a
+                        href='#Klass.isClass'
+                        class='regular pre-open'>
+                        .isClass
+                      </a></li>
+                    
+                      <li><a
+                        href='#Klass.isWeird'
+                        class='regular pre-open'>
+                        .isWeird
+                      </a></li>
+                    
+                      <li><a
+                        href='#Klass.isBuffer'
+                        class='regular pre-open'>
+                        .isBuffer
+                      </a></li>
+                    
+                      <li><a
+                        href='#Klass.isArrayOfBuffers'
+                        class='regular pre-open'>
+                        .isArrayOfBuffers
+                      </a></li>
+                    
+                      <li><a
+                        href='#Klass.MAGIC_NUMBER'
+                        class='regular pre-open'>
+                        .MAGIC_NUMBER
+                      </a></li>
+                    
+                      <li><a
+                        href='#Klass.event:event'
+                        class='regular pre-open'>
+                        .event
+                      </a></li>
+                    
+                    </ul>
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'><span>Instance members</span></li>
+                      
+                      <li><a
+                        href='#Klass#getFoo'
+                        class='regular pre-open'>
+                        #getFoo
+                      </a></li>
+                      
+                      <li><a
+                        href='#Klass#withOptions'
+                        class='regular pre-open'>
+                        #withOptions
+                      </a></li>
+                      
+                    </ul>
+                  
+                  
+                </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#customerror'
+                  class="">
+                  CustomError
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#bar'
+                  class="">
+                  bar
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#bar'
+                  class="">
+                  bar
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#bar'
+                  class="">
+                  bar
+                  
+                </a>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#foo'
+                  class=" toggle-sibling">
+                  Foo
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  
+                    <ul class='list-reset py1-ul pl1'>
+                      <li class='h5'><span>Instance members</span></li>
+                      
+                      <li><a
+                        href='#Foo#bar'
+                        class='regular pre-open'>
+                        #bar
+                      </a></li>
+                      
+                    </ul>
+                  
+                  
+                </div>
+                
+                </li>
+              
+                
+                <li><a
+                  href='#customstreams'
+                  class=" toggle-sibling">
+                  customStreams
+                  <span class='icon'>▸</span>
+                </a>
+                
+                <div class='toggle-target display-none'>
+                  
+                  <ul class='list-reset py1-ul pl1'>
+                    <li class='h5'><span>Static members</span></li>
+                    
+                      <li><a
+                        href='#customStreams.passthrough'
+                        class='regular pre-open'>
+                        .passthrough
+                      </a></li>
+                    
+                    </ul>
+                  
+                  
+                  
+                </div>
+                
+                </li>
+              
+            </ul>
+          </div>
+          <div class='mt1 h6 quiet'>
+            <a href='http://documentation.js.org/reading-documentation.html'>Need help reading this?</a>
+          </div>
+        </div>
+      </div>
+      <div class='fix-margin-3'>
+        
+          
+            <div class='keyline-top-not py2'><section class='py2 clearfix'>
+
+  <h2 id='Highlighted section' class='mt0'>
+    Highlighted section
+  </h2>
+
+  
+    <p>The public key is a base64 encoded string of a protobuf containing an RSA DER
+buffer. This uses a node buffer to pass the base64 encoded public key protobuf
+to the multihash for ID generation.</p>
+<pre class='hljs'><span class="hljs-keyword">var</span> PeerId = <span class="hljs-built_in">require</span>(<span class="hljs-string">'peer-id'</span>)
+
+PeerId.create({ <span class="hljs-attr">bits</span>: <span class="hljs-number">1024</span> }, (err, id) =&gt; {
+  <span class="hljs-built_in">console</span>.log(<span class="hljs-built_in">JSON</span>.stringify(id.toJSON(), <span class="hljs-literal">null</span>, <span class="hljs-number">2</span>)
+})</pre>
+<pre><code>{
+  "id": "Qma9T5YraSnpRDZqRR4krcSJabThc8nwZuJV3LercPHufi",
+  "privKey": "CAAS4AQwggJcAgEAAoGBAMBgbIqyOL26oV3nGPBYrdpbv..",
+  "pubKey": "CAASogEwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAMBgbIqyOL26oV3nGPBYrdpbvzCY..."
+}
+</code></pre>
+
+  
+</section>
+</div>
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='klass'>
+      Klass
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Creates a new Klass</p>
+
+
+  <div class='pre p1 fill-light mt0'>new Klass(foo: any)</div>
+
+  
+    <p>
+      Extends
+      
+        <a href="https://nodejs.org/api/stream.html#stream_class_stream_writable">Stream.Writable</a>
+      
+    </p>
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>foo</span> <code class='quiet'>(any)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Static Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='Klass.isClass'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isClass(other, also)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Decide whether an object is a Klass instance
+This is a [klasssic]<a href="#klass">Klass</a>
+This is a [link to something that does not exist]<a href="DoesNot">DoesNot</a></p>
+
+
+  <div class='pre p1 fill-light mt0'>isClass(other: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, also: any): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>other</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>also</span> <code class='quiet'>(any)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        whether the other thing is a Klass
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='Klass.isWeird'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isWeird(other)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>A function that triggers the case where the autolinker doesn't find
+the referenced class type</p>
+
+
+  <div class='pre p1 fill-light mt0'>isWeird(other: Weird): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>other</span> <code class='quiet'>(Weird)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        whether the other thing is a Klass
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='Klass.isBuffer'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isBuffer(buf, size = 0)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>This method takes a Buffer object that will be linked to nodejs.org</p>
+
+
+  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>buf</span> <code class='quiet'>((<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>))</code>
+	    
+          </div>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>size</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?
+            = <code>0</code>)</code>
+	    size
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></code>:
+        whether the other thing is a Klass
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='Klass.isArrayOfBuffers'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>isArrayOfBuffers(buffers)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>This method takes an array of buffers and counts them</p>
+
+
+  <div class='pre p1 fill-light mt0'>isArrayOfBuffers(buffers: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://nodejs.org/api/buffer.html">Buffer</a>>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>buffers</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;<a href="https://nodejs.org/api/buffer.html">Buffer</a>>)</code>
+	    some buffers
+
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>:
+        how many
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> k = <span class="hljs-keyword">new</span> Klass();
+k.isArrayOfBuffers();</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='Klass.MAGIC_NUMBER'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>MAGIC_NUMBER</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>A magic number that identifies this Klass.</p>
+
+
+  <div class='pre p1 fill-light mt0'>MAGIC_NUMBER</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='Klass.event:event'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>event</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Klass event</p>
+
+
+  <div class='pre p1 fill-light mt0'>event</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='Klass#getFoo'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>getFoo()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>Get this Klass's foo</p>
+
+
+  <div class='pre p1 fill-light mt0'>getFoo(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></code>:
+        foo
+
+      
+    
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      <p><p>this shows you how to getFoo</p>
+</p>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> x = foo.getFoo();</pre>
+    
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='Klass#withOptions'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>withOptions(options, otherOptions)</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>A function with an options parameter</p>
+
+
+  <div class='pre p1 fill-light mt0'>withOptions(options: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, otherOptions: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>)</code>
+	    
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a></code>
+                  </td>
+                  <td class='break-word'><span></span></td>
+                </tr>
+              
+                <tr>
+                  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a></code>
+                  </td>
+                  <td class='break-word'><span></span></td>
+                </tr>
+              
+            </tbody>
+          </table>
+          
+        </div>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='customerror'>
+      CustomError
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>a typedef with nested properties</p>
+
+
+  <div class='pre p1 fill-light mt0'>CustomError</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Properties</div>
+    <div>
+      
+        <div class='space-bottom0'>
+          <span class='code bold'>error</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">object</a>)</code>
+          : An error
+
+          
+            <ul>
+              
+                <li><code>error.code</code> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+                  
+                  <p>The error's code</p>
+</li>
+              
+                <li><code>error.description</code> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>
+                  
+                  <p>The error's description</p>
+</li>
+              
+            </ul>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='bar'>
+      bar
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Get an instance of <a href="#klass">Klass</a>. Will make
+a <a href="#klass">klass instance multiword</a>,
+like a <a href="#klass">klass</a></p>
+
+
+  <div class='pre p1 fill-light mt0'>bar(): <a href="#klass">Klass</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="#klass">Klass</a></code>:
+        that class
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='bar'>
+      bar
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Rest property function</p>
+
+
+  <div class='pre p1 fill-light mt0'>bar(toys: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>toys</span> <code class='quiet'>(...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>)</code>
+	    
+          </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></code>:
+        nothing
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='bar'>
+      bar
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>Get an instance of <a href="#klass">Klass</a>. Will make
+a <a href="#klass">klass instance multiword</a>,
+like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a> input.</p>
+
+
+  <div class='pre p1 fill-light mt0'>bar(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+    
+      <div class='py1 quiet mt1 prose-big'>Returns</div>
+      <code><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></code>:
+        nothing
+
+      
+    
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='foo'>
+      Foo
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>This is Foo</p>
+
+
+  <div class='pre p1 fill-light mt0'>new Foo()</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Instance Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='Foo#bar'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>bar</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>This is bar</p>
+
+
+  <div class='pre p1 fill-light mt0'>bar</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+</section>
+
+          
+        
+          
+            <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+  <div class='clearfix'>
+    
+    <h3 class='fl m0' id='customstreams'>
+      customStreams
+    </h3>
+    
+    
+  </div>
+  
+
+  <p>I am the container of stream types</p>
+
+
+  <div class='pre p1 fill-light mt0'>customStreams</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Static Members</div>
+    <div class="clearfix">
+  
+    <div class='border-bottom' id='customStreams.passthrough'>
+      <div class="clearfix small pointer toggle-sibling">
+        <div class="py1 contain">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>new passthrough()</span>
+        </div>
+      </div>
+      <div class="clearfix display-none toggle-target">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>I am a passthrough stream that belongs to customStreams</p>
+
+
+  <div class='pre p1 fill-light mt0'>new passthrough()</div>
+
+  
+
+  
+  
+  
+  
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+</div>
+
+  
+
+  
+
+  
+</section>
+
+          
+        
+      </div>
+    </div>
+  </div>
+  <script src='assets/anchor.js'></script>
+  <script src='assets/site.js'></script>
+</body>
+</html>

--- a/test/fixture/html/nested.input.js
+++ b/test/fixture/html/nested.input.js
@@ -13,7 +13,7 @@ function Klass(foo) {
  * Get this Klass's foo
  * @returns {Number} foo
  * @example <caption>this shows you how to getFoo</caption>
- * foo.getFoo();
+ * var x = foo.getFoo();
  */
 Klass.prototype.getFoo = function () {
   return this.foo;

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -698,7 +698,7 @@ k.isArrayOfBuffers();</pre>
     
       <p><p>this shows you how to getFoo</p>
 </p>
-      <pre class='p1 overflow-auto round fill-light'>foo.getFoo();</pre>
+      <pre class='p1 overflow-auto round fill-light'><span class="hljs-keyword">var</span> x = foo.getFoo();</pre>
     
   
 


### PR DESCRIPTION
Port simple highlighter to run on all code snippets. cc @dignifiedquire 