### PR TITLE
Output typedef content in Markdown and HTML. Fixes #359

### DIFF
--- a/default_theme/section._
+++ b/default_theme/section._
@@ -19,6 +19,13 @@
 
   <div class='pre p1 fill-light mt0'><%= signature(section) %></div>
 
+  <% if (section.type) { %>
+    <p>
+      Type:
+      <%= formatType(section.type) %>
+    </p>
+  <% } %>
+
   <% if (section.augments) { %>
     <p>
       Extends

--- a/lib/output/markdown_ast.js
+++ b/lib/output/markdown_ast.js
@@ -43,6 +43,14 @@ function commentsToAST(comments, options, callback) {
    */
   function generate(depth, comment) {
 
+    function typeSection(comment) {
+      return comment.type && u('paragraph', [
+        u('text', 'Type: ')
+      ].concat(
+        formatType(comment.type)
+      ));
+    }
+
     function paramList(params) {
       return u('list', { ordered: false }, params.map(function (param) {
         return u('listItem', [
@@ -176,6 +184,7 @@ function commentsToAST(comments, options, callback) {
     .concat(githubLink(comment))
     .concat(augmentsLink(comment))
     .concat(comment.description ? comment.description.children : [])
+    .concat(typeSection(comment))
     .concat(paramSection(comment))
     .concat(propertySection(comment))
     .concat(examplesSection(comment))

--- a/test/fixture/document-exported.output.md
+++ b/test/fixture/document-exported.output.md
@@ -34,6 +34,8 @@
 
 # T5
 
+Type: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
+
 # y2Default
 
 # y4
@@ -68,9 +70,15 @@ Returns **void**
 
 # T
 
+Type: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
 # T2
 
+Type: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
+
 # T4
+
+Type: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 # f4
 

--- a/test/fixture/document-exported.output.md.json
+++ b/test/fixture/document-exported.output.md.json
@@ -227,6 +227,26 @@
       ]
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "boolean"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "depth": 1,
       "type": "heading",
       "children": [
@@ -484,6 +504,26 @@
       ]
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "depth": 1,
       "type": "heading",
       "children": [
@@ -494,12 +534,52 @@
       ]
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "depth": 1,
       "type": "heading",
       "children": [
         {
           "type": "text",
           "value": "T4"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "string"
+            }
+          ]
         }
       ]
     },

--- a/test/fixture/html/nested.config-output.html
+++ b/test/fixture/html/nested.config-output.html
@@ -258,6 +258,8 @@ PeerId.create({ <span class="hljs-attr">bits</span>: <span class="hljs-number">1
   <div class='pre p1 fill-light mt0'>new Klass(foo: any)</div>
 
   
+
+  
     <p>
       Extends
       
@@ -317,6 +319,8 @@ This is a [link to something that does not exist]<a href="DoesNot">DoesNot</a></
 
 
   <div class='pre p1 fill-light mt0'>isClass(other: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, also: any): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
 
   
 
@@ -396,6 +400,8 @@ the referenced class type</p>
   
 
   
+
+  
   
   
   
@@ -458,6 +464,8 @@ the referenced class type</p>
 
 
   <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
 
   
 
@@ -538,6 +546,8 @@ the referenced class type</p>
   
 
   
+
+  
   
   
   
@@ -612,6 +622,8 @@ k.isArrayOfBuffers();</pre>
   
 
   
+
+  
   
   
   
@@ -653,6 +665,8 @@ k.isArrayOfBuffers();</pre>
 
 
   <div class='pre p1 fill-light mt0'>event</div>
+
+  
 
   
 
@@ -706,6 +720,8 @@ k.isArrayOfBuffers();</pre>
 
 
   <div class='pre p1 fill-light mt0'>getFoo(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></div>
+
+  
 
   
 
@@ -766,6 +782,8 @@ k.isArrayOfBuffers();</pre>
 
 
   <div class='pre p1 fill-light mt0'>withOptions(options: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, otherOptions: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
+
+  
 
   
 
@@ -875,6 +893,8 @@ k.isArrayOfBuffers();</pre>
   
 
   
+
+  
   
   
   
@@ -949,6 +969,8 @@ like a <a href="#klass">klass</a></p>
   
 
   
+
+  
   
   
   
@@ -999,6 +1021,8 @@ like a <a href="#klass">klass</a></p>
 
 
   <div class='pre p1 fill-light mt0'>bar(toys: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+
+  
 
   
 
@@ -1072,6 +1096,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
   
 
   
+
+  
   
   
   
@@ -1126,6 +1152,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
   
 
   
+
+  
   
   
   
@@ -1163,6 +1191,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
 
 
   <div class='pre p1 fill-light mt0'>bar</div>
+
+  
 
   
 
@@ -1223,6 +1253,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
   
 
   
+
+  
   
   
   
@@ -1258,6 +1290,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
 
 
   <div class='pre p1 fill-light mt0'>new passthrough()</div>
+
+  
 
   
 

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -220,6 +220,8 @@
   <div class='pre p1 fill-light mt0'>new Klass(foo: any)</div>
 
   
+
+  
     <p>
       Extends
       
@@ -279,6 +281,8 @@ This is a [link to something that does not exist]<a href="DoesNot">DoesNot</a></
 
 
   <div class='pre p1 fill-light mt0'>isClass(other: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, also: any): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
 
   
 
@@ -358,6 +362,8 @@ the referenced class type</p>
   
 
   
+
+  
   
   
   
@@ -420,6 +426,8 @@ the referenced class type</p>
 
 
   <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+
+  
 
   
 
@@ -500,6 +508,8 @@ the referenced class type</p>
   
 
   
+
+  
   
   
   
@@ -574,6 +584,8 @@ k.isArrayOfBuffers();</pre>
   
 
   
+
+  
   
   
   
@@ -615,6 +627,8 @@ k.isArrayOfBuffers();</pre>
 
 
   <div class='pre p1 fill-light mt0'>event</div>
+
+  
 
   
 
@@ -668,6 +682,8 @@ k.isArrayOfBuffers();</pre>
 
 
   <div class='pre p1 fill-light mt0'>getFoo(): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a></div>
+
+  
 
   
 
@@ -728,6 +744,8 @@ k.isArrayOfBuffers();</pre>
 
 
   <div class='pre p1 fill-light mt0'>withOptions(options: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a>, otherOptions: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?)</div>
+
+  
 
   
 
@@ -837,6 +855,8 @@ k.isArrayOfBuffers();</pre>
   
 
   
+
+  
   
   
   
@@ -911,6 +931,8 @@ like a <a href="#klass">klass</a></p>
   
 
   
+
+  
   
   
   
@@ -961,6 +983,8 @@ like a <a href="#klass">klass</a></p>
 
 
   <div class='pre p1 fill-light mt0'>bar(toys: ...<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">Number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined">undefined</a></div>
+
+  
 
   
 
@@ -1034,6 +1058,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
   
 
   
+
+  
   
   
   
@@ -1088,6 +1114,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
   
 
   
+
+  
   
   
   
@@ -1125,6 +1153,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
 
 
   <div class='pre p1 fill-light mt0'>bar</div>
+
+  
 
   
 
@@ -1185,6 +1215,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
   
 
   
+
+  
   
   
   
@@ -1220,6 +1252,8 @@ like a <a href="#klass">klass</a>. This needs a <a href="https://developer.mozil
 
 
   <div class='pre p1 fill-light mt0'>new passthrough()</div>
+
+  
 
   
 

--- a/test/fixture/optional-record-field-type.output.md
+++ b/test/fixture/optional-record-field-type.output.md
@@ -2,6 +2,8 @@
 
 # Record
 
+Type: {opt: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?, req: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)}
+
 **Properties**
 
 -   `opt` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** 

--- a/test/fixture/optional-record-field-type.output.md.json
+++ b/test/fixture/optional-record-field-type.output.md.json
@@ -16,6 +16,61 @@
       ]
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "opt: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "?"
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "req: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "string"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "}"
+        }
+      ]
+    },
+    {
       "type": "strong",
       "children": [
         {

--- a/test/fixture/sync/flow-types.input.js
+++ b/test/fixture/sync/flow-types.input.js
@@ -60,3 +60,13 @@ function objectParamFn(x: { a: number }) {}
 
 /** hi */
 function objectParamFn(x: (y:Foo) => Bar) {}
+
+/** My type */
+export type T = number;
+
+/**
+ * Define my object API
+ */
+export type SomeObjectAPI = {
+  method: (param: string) => boolean
+}

--- a/test/fixture/sync/flow-types.output.json
+++ b/test/fixture/sync/flow-types.output.json
@@ -758,6 +758,101 @@
           "children": [
             {
               "type": "text",
+              "value": "My type",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 8,
+                  "offset": 7
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 8,
+              "offset": 7
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8,
+          "offset": 7
+        }
+      }
+    },
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 64,
+        "column": 0
+      },
+      "end": {
+        "line": 64,
+        "column": 14
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 65,
+          "column": 0
+        },
+        "end": {
+          "line": 65,
+          "column": 23
+        }
+      }
+    },
+    "errors": [],
+    "name": "T",
+    "kind": "typedef",
+    "type": {
+      "type": "NameExpression",
+      "name": "number"
+    },
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "T",
+        "kind": "typedef"
+      }
+    ],
+    "namespace": "T"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
               "value": "Very Important Transform",
               "position": {
                 "start": {
@@ -1210,5 +1305,122 @@
       }
     ],
     "namespace": "objectParamFn"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Define my object API",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21,
+                  "offset": 20
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 21,
+              "offset": 20
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 21,
+          "offset": 20
+        }
+      }
+    },
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 67,
+        "column": 0
+      },
+      "end": {
+        "line": 69,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 70,
+          "column": 0
+        },
+        "end": {
+          "line": 72,
+          "column": 1
+        }
+      }
+    },
+    "errors": [],
+    "name": "SomeObjectAPI",
+    "kind": "typedef",
+    "type": {
+      "type": "RecordType",
+      "fields": [
+        {
+          "type": "FieldType",
+          "key": "method",
+          "value": {
+            "type": "FunctionType",
+            "params": [
+              {
+                "type": "ParameterType",
+                "name": "param",
+                "expression": {
+                  "type": "NameExpression",
+                  "name": "string"
+                }
+              }
+            ],
+            "result": {
+              "type": "NameExpression",
+              "name": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "members": {
+      "instance": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "SomeObjectAPI",
+        "kind": "typedef"
+      }
+    ],
+    "namespace": "SomeObjectAPI"
   }
 ]

--- a/test/fixture/sync/flow-types.output.md
+++ b/test/fixture/sync/flow-types.output.md
@@ -19,6 +19,8 @@ Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refer
 
 A 2D point.
 
+Type: {x: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), y: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), rgb: {hex: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)}, props: {radius: {x: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)}}}
+
 **Properties**
 
 -   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** this is a prop
@@ -33,6 +35,8 @@ A 2D point.
 
 A type with entirely derived properties
 
+Type: {x: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), y: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), z: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?}
+
 **Properties**
 
 -   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
@@ -42,6 +46,14 @@ A type with entirely derived properties
 # T
 
 Just an alias for an array of strings
+
+Type: [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>
+
+# T
+
+My type
+
+Type: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
 
 # veryImportantTransform
 
@@ -77,3 +89,9 @@ hi
 **Parameters**
 
 -   `x` **function (y: Foo): Bar** 
+
+# SomeObjectAPI
+
+Define my object API
+
+Type: {method: function (param: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)}

--- a/test/fixture/sync/flow-types.output.md.json
+++ b/test/fixture/sync/flow-types.output.md.json
@@ -384,6 +384,131 @@
       }
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "x: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "y: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "rgb: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "hex: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "string"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "}"
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "props: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "radius: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "x: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "}"
+        },
+        {
+          "type": "text",
+          "value": "}"
+        },
+        {
+          "type": "text",
+          "value": "}"
+        }
+      ]
+    },
+    {
       "type": "strong",
       "children": [
         {
@@ -811,6 +936,80 @@
       }
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "x: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "y: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": ", "
+        },
+        {
+          "type": "text",
+          "value": "z: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "?"
+        },
+        {
+          "type": "text",
+          "value": "}"
+        }
+      ]
+    },
+    {
       "type": "strong",
       "children": [
         {
@@ -987,6 +1186,110 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "Array"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "<"
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "string"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": ">"
+        }
+      ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "T"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "My type",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 8,
+              "offset": 7
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 8,
+          "offset": 7
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "number"
+            }
+          ]
+        }
+      ]
     },
     {
       "depth": 1,
@@ -1530,6 +1833,110 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    {
+      "depth": 1,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "SomeObjectAPI"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Define my object API",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 21,
+              "offset": 20
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 21,
+          "offset": 20
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "type": "text",
+          "value": "{"
+        },
+        {
+          "type": "text",
+          "value": "method: "
+        },
+        {
+          "type": "text",
+          "value": "function ("
+        },
+        {
+          "type": "text",
+          "value": "param: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "string"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": ")"
+        },
+        {
+          "type": "text",
+          "value": ": "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "boolean"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "}"
         }
       ]
     }

--- a/test/fixture/sync/typedef.output.md
+++ b/test/fixture/sync/typedef.output.md
@@ -4,6 +4,8 @@
 
 A type definition.
 
+Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+
 **Properties**
 
 -   `prop1` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** one property

--- a/test/fixture/sync/typedef.output.md.json
+++ b/test/fixture/sync/typedef.output.md.json
@@ -51,6 +51,26 @@
       }
     },
     {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Type: "
+        },
+        {
+          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+          "type": "link",
+          "children": [
+            {
+              "type": "text",
+              "value": "Object"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "type": "strong",
       "children": [
         {


### PR DESCRIPTION
For `typedefs`, we get `type` information on the comment but we weren't outputting it. This adds output for that type information in Markdown and HTML modes (the information was already included in JSON mode).

* Should fix #359 - cc @trodrigues