### PR TITLE
fix(parser): Avoid error about deoptimization on very large files

### DIFF
--- a/lib/input/dependency.js
+++ b/lib/input/dependency.js
@@ -40,6 +40,7 @@ function dependencyStream(indexes, options, callback) {
       }),
     transform: [babelify.configure({
       sourceMap: false,
+      compact: false,
       presets: [
         require('babel-preset-es2015'),
         require('babel-preset-stage-0'),

--- a/test/bin.js
+++ b/test/bin.js
@@ -375,3 +375,20 @@ test('build --document-exported', function (t) {
     t.end();
   }, false);
 }, options);
+
+test('build large file without error (no deoptimized styling error)', function (t) {
+
+  var dstFile = path.join(os.tmpdir(), (Date.now() + Math.random()).toString()) + '.js';
+  var contents = '';
+  for (var i = 0; i < 4e4; i++) {
+    contents += '/* - */\n';
+  }
+  fs.writeFileSync(dstFile, contents, 'utf8');
+
+  documentation(['build ' + dstFile], {}, function (err, data, stderr) {
+    t.error(err);
+    t.equal(stderr, '');
+    fs.unlinkSync(dstFile);
+    t.end();
+  }, false);
+}, options);


### PR DESCRIPTION
This sets compact: false for babelify, so that Babel doesn't complain about not being able to

compact'ify very large files

* https://github.com/documentationjs/gulp-documentation/issues/14