### PR TITLE
added missing installation instructions in GETTING_STARTED.md

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Assuming that you've installed the `documentation` application, how do you
+Assuming that you've installed the `documentation` application (`npm install -g documentation` if you haven't), how do you
 get started actually using it to document your code?
 
 Traditionally you might write documentation by creating a new Markdown


### PR DESCRIPTION
crucial since home page links to GETTING_STARTED.md, without first showing any installation instructions -- those are currently only found in the README.md / GH repo landing page.