### PR TITLE
Fix anchor for not toc targets

### DIFF
--- a/default_theme/note._
+++ b/default_theme/note._
@@ -1,6 +1,6 @@
 <section class='py2 clearfix'>
 
-  <h2 id='<%- note.namespace %>' class='mt0'>
+  <h2 id='<%- slug(note.namespace) %>' class='mt0'>
     <%- note.name %>
   </h2>
 


### PR DESCRIPTION
Clicking on toc items generated from the documentation.yaml file didnt work. The target id was not properly slugged. Always slug your target. Very important.