### PR TITLE
Fix bug parsing anonymous closure types from Flow.

### DIFF
--- a/lib/flow_doctrine.js
+++ b/lib/flow_doctrine.js
@@ -98,9 +98,13 @@ function flowDoctrine(type/*: Object */)/*: DoctrineType*/ {
     return {
       type: 'FunctionType',
       params: type.params.map(param => {
+        let name = '';
+        if (param.name && param.name.name) {
+            name = param.name.name;
+        }
         return {
           type: 'ParameterType',
-          name: param.name.name,
+          name: name,
           expression: flowDoctrine(param.typeAnnotation)
         };
       }),

--- a/lib/output/util/format_type.js
+++ b/lib/output/util/format_type.js
@@ -118,7 +118,10 @@ function formatType(getHref/*: Function*/, node/*: ?Object */) {
   case Syntax.NameExpression:
     return [link(node.name, getHref)];
   case Syntax.ParameterType:
-    return [t(node.name + ': ')].concat(formatType(getHref, node.expression));
+    if (node.name) {
+        result.push(t(node.name + ': '));
+    }
+    return result.concat(formatType(getHref, node.expression));
 
   case Syntax.TypeApplication:
     return formatType(getHref, node.expression)

--- a/test/lib/flow_doctrine.js
+++ b/test/lib/flow_doctrine.js
@@ -181,6 +181,19 @@ test('flowDoctrine', function (t) {
       name: 'boolean'
     }, 'boolean');
 
+  t.deepEqual(toDoctrineType('any => any'),
+    {
+      type: 'FunctionType',
+      params: [
+        {
+          expression: {type: 'AllLiteral'},
+          name: '',
+          type: 'ParameterType'
+        }
+      ],
+      result: {type: 'AllLiteral'},
+    }, '');
+
   t.deepEqual(toDoctrineType('undefined'),
     {
       type: 'NameExpression',


### PR DESCRIPTION
If no parameter name exists in a function type, then set it to empty. Also,
fix the formatter so that `{param}: {ty}` is formatted as `{ty}` when
`{param}` is empty.

Fixes #671