### PR TITLE
FIX: added code path for type RestElement

### DIFF
--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -96,6 +96,8 @@ function paramToDoc(
       return paramToDoc(property, comment, i, prefix + '$' + String(i) + '.');
     } else if (property.type === 'RestProperty') {
       return paramToDoc(property, comment, i, prefix + '$' + String(i) + '.');
+    } else if (property.type === 'RestElement') {
+      return paramToDoc(property, comment, i, prefix + '$' + String(i) + '.');
     }
     throw new Error(`Unknown property encountered: ${property.type}`);
   }

--- a/test/fixture/params.input.js
+++ b/test/fixture/params.input.js
@@ -94,3 +94,16 @@ export const myfunc = (x = 123) => x;
 function foo(address) {
   return address;
 }
+
+/**
+ * This tests our support for iterator rest inside an
+ * iterator destructure (RestElement)
+ *
+ * @param {any} $0.x head of iterator
+ * @param {any[]} ...$0.xs body of iterator
+ *
+ * @returns {any[]} rotated such that the last element was the first
+ */
+export function rotate([x, ...xs]) {
+  return [...xs, x];
+}

--- a/test/fixture/params.output.json
+++ b/test/fixture/params.output.json
@@ -2461,5 +2461,314 @@
       }
     ],
     "namespace": "foo"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This tests our support for iterator rest inside an\niterator destructure (RestElement)",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 2,
+                  "column": 35,
+                  "offset": 85
+                },
+                "indent": [
+                  1
+                ]
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 35,
+              "offset": 85
+            },
+            "indent": [
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 35,
+          "offset": 85
+        }
+      }
+    },
+    "tags": [
+      {
+        "title": "param",
+        "description": "head of iterator",
+        "lineNumber": 4,
+        "type": {
+          "type": "NameExpression",
+          "name": "any"
+        },
+        "name": "$0.x"
+      },
+      {
+        "title": "param",
+        "description": "...$0.xs body of iterator",
+        "lineNumber": 5,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Array"
+          },
+          "applications": [
+            {
+              "type": "NameExpression",
+              "name": "any"
+            }
+          ]
+        },
+        "name": null,
+        "errors": [
+          "Missing or invalid tag name"
+        ]
+      },
+      {
+        "title": "returns",
+        "description": "rotated such that the last element was the first",
+        "lineNumber": 7,
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Array"
+          },
+          "applications": [
+            {
+              "type": "NameExpression",
+              "name": "any"
+            }
+          ]
+        }
+      }
+    ],
+    "loc": {
+      "start": {
+        "line": 98,
+        "column": 0
+      },
+      "end": {
+        "line": 106,
+        "column": 3
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 0
+        },
+        "end": {
+          "line": 109,
+          "column": 1
+        }
+      }
+    },
+    "augments": [],
+    "errors": [
+      {
+        "message": "Missing or invalid tag name"
+      }
+    ],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "$0",
+        "type": {
+          "type": "AllLiteral"
+        },
+        "properties": [
+          {
+            "title": "param",
+            "name": "$0.x",
+            "lineNumber": 4,
+            "description": {
+              "type": "root",
+              "children": [
+                {
+                  "type": "paragraph",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "head of iterator",
+                      "position": {
+                        "start": {
+                          "line": 1,
+                          "column": 1,
+                          "offset": 0
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 17,
+                          "offset": 16
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 17,
+                      "offset": 16
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 17,
+                  "offset": 16
+                }
+              }
+            },
+            "type": {
+              "type": "NameExpression",
+              "name": "any"
+            }
+          },
+          {
+            "title": "param",
+            "name": "$0.xs",
+            "lineNumber": 107,
+            "type": {
+              "type": "RestType"
+            }
+          }
+        ]
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "description": {
+          "type": "root",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "rotated such that the last element was the first",
+                  "position": {
+                    "start": {
+                      "line": 1,
+                      "column": 1,
+                      "offset": 0
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 49,
+                      "offset": 48
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 49,
+                  "offset": 48
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            }
+          }
+        },
+        "title": "returns",
+        "type": {
+          "type": "TypeApplication",
+          "expression": {
+            "type": "NameExpression",
+            "name": "Array"
+          },
+          "applications": [
+            {
+              "type": "NameExpression",
+              "name": "any"
+            }
+          ]
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "rotate",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "rotate",
+        "kind": "function"
+      }
+    ],
+    "namespace": "rotate"
   }
 ]

--- a/test/fixture/params.output.md
+++ b/test/fixture/params.output.md
@@ -13,6 +13,7 @@
 -   [GeoJSONSource](#geojsonsource)
 -   [myfunc](#myfunc)
 -   [foo](#foo-1)
+-   [rotate](#rotate)
 
 ## addThem
 
@@ -123,3 +124,16 @@ or any type information we could infer from annotations.
 **Parameters**
 
 -   `address`  An IPv6 address string
+
+## rotate
+
+This tests our support for iterator rest inside an
+iterator destructure (RestElement)
+
+**Parameters**
+
+-   `$0` **any** 
+    -   `$0.x` **any** head of iterator
+    -   `$0.xs` **...any** 
+
+Returns **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;any>** rotated such that the last element was the first

--- a/test/fixture/params.output.md.json
+++ b/test/fixture/params.output.md.json
@@ -2190,6 +2190,284 @@
           ]
         }
       ]
+    },
+    {
+      "depth": 2,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "rotate"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "This tests our support for iterator rest inside an\niterator destructure (RestElement)",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 2,
+              "column": 35,
+              "offset": 85
+            },
+            "indent": [
+              1
+            ]
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 2,
+          "column": 35,
+          "offset": 85
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "strong",
+      "children": [
+        {
+          "type": "text",
+          "value": "Parameters"
+        }
+      ]
+    },
+    {
+      "ordered": false,
+      "type": "list",
+      "children": [
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "$0"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "any"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "ordered": false,
+              "type": "list",
+              "children": [
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "$0.x"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "any"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "paragraph",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "head of iterator",
+                              "position": {
+                                "start": {
+                                  "line": 1,
+                                  "column": 1,
+                                  "offset": 0
+                                },
+                                "end": {
+                                  "line": 1,
+                                  "column": 17,
+                                  "offset": 16
+                                },
+                                "indent": []
+                              }
+                            }
+                          ],
+                          "position": {
+                            "start": {
+                              "line": 1,
+                              "column": 1,
+                              "offset": 0
+                            },
+                            "end": {
+                              "line": 1,
+                              "column": 17,
+                              "offset": 16
+                            },
+                            "indent": []
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "listItem",
+                  "children": [
+                    {
+                      "type": "paragraph",
+                      "children": [
+                        {
+                          "type": "inlineCode",
+                          "value": "$0.xs"
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        },
+                        {
+                          "type": "strong",
+                          "children": [
+                            {
+                              "type": "text",
+                              "value": "..."
+                            },
+                            {
+                              "type": "text",
+                              "value": "any"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "value": " "
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Returns "
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+              "type": "link",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Array"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": "<"
+            },
+            {
+              "type": "text",
+              "value": "any"
+            },
+            {
+              "type": "text",
+              "value": ">"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": " "
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "rotated such that the last element was the first",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 49,
+                  "offset": 48
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "indent": []
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hey this is a quick fix that I needed to document my code and figured it would be appreciated upstream. Keen to hear what needs to be done to get the merged 👍 .

## Problem
- documentation throws on a param of RestElement.

i.e.

```javascript
/**
 * takes an array of elements and rotates the values,
 * such that the first element is shifted to the end.
 */
export function rotate([ x: any, ...xs: any[] ]): any[] {
  return [ ...xs, x ]
}
```

## Solution
- added a code path to accomodate for such entities.


## Todo
- [x] add tests. (I noticed the method paramToDocs didn't have any tests and that the related test file and source file were edited very recently so I wasn't sure if this was in progress).
  