### PR TITLE
test(description-tag): Confirm behavior of description tag with tests

### DIFF
--- a/test/fixture/meta.input.js
+++ b/test/fixture/meta.input.js
@@ -1,6 +1,7 @@
 /**
- * This function returns the number one.
+ * This description is ignored because the method has a tagged description.
  * @returns {number} numberone
+ * @description This function returns the number one.
  * @see {@link http://github.com/|github}
  * @see TestCase
  * @see [markdown link](http://foo.com/)

--- a/test/fixture/meta.output.json
+++ b/test/fixture/meta.output.json
@@ -63,39 +63,44 @@
         }
       },
       {
-        "title": "see",
-        "description": "{@link http://github.com/|github}",
+        "title": "description",
+        "description": "This function returns the number one.",
         "lineNumber": 3
       },
       {
         "title": "see",
-        "description": "TestCase",
+        "description": "{@link http://github.com/|github}",
         "lineNumber": 4
       },
       {
         "title": "see",
-        "description": "[markdown link](http://foo.com/)",
+        "description": "TestCase",
         "lineNumber": 5
+      },
+      {
+        "title": "see",
+        "description": "[markdown link](http://foo.com/)",
+        "lineNumber": 6
       },
       {
         "title": "version",
         "description": "1.0.0",
-        "lineNumber": 6
+        "lineNumber": 7
       },
       {
         "title": "since",
         "description": "2.0.0",
-        "lineNumber": 7
+        "lineNumber": 8
       },
       {
         "title": "copyright",
         "description": "Tom MacWright",
-        "lineNumber": 8
+        "lineNumber": 9
       },
       {
         "title": "license",
         "description": "BSD",
-        "lineNumber": 9
+        "lineNumber": 10
       }
     ],
     "loc": {
@@ -104,18 +109,18 @@
         "column": 0
       },
       "end": {
-        "line": 11,
+        "line": 12,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 12,
+          "line": 13,
           "column": 0
         },
         "end": {
-          "line": 15,
+          "line": 16,
           "column": 2
         }
       }

--- a/test/lib/parse.js
+++ b/test/lib/parse.js
@@ -107,6 +107,21 @@ test('parse - @augments', function(t) {
   t.end();
 });
 
+test('parse - @description', function(t) {
+  t.deepEqual(
+    evaluate(function() {
+      /**
+       * This is a free-form description
+       * @description This tagged description wins, and [is markdown](http://markdown.com).
+       */
+    })[0].description,
+    remark().parse('This tagged description wins, and [is markdown](http://markdown.com).'),
+    'description'
+  );
+
+  t.end();
+});
+
 /*
  * Dossier-style augments tag
  * https://github.com/google/closure-library/issues/746


### PR DESCRIPTION
The `@description` tag allows people to specify a description of a node in any place in the JSDoc
comment, instead of only at the beginning.

Fixes https://github.com/documentationjs/documentation/issues/341