### PR TITLE
test(fixtures): Add utf8 test fixtures

### DIFF
--- a/test/fixture/es6.input.js
+++ b/test/fixture/es6.input.js
@@ -130,7 +130,10 @@ function iAmPrivate() {}
 function iAmProtected() {}
 
 /**
- * A public function
+ * A public function. This uses a sampling of UTF8 to make sure we're on board:
+ * ¥ · £ · € · $ · ¢ · ₡ · ₢ · ₣ · ₤ · ₥ · ₦ · ₧ · ₨ · ₩ · ₪ · ₫ · ₭ · ₮ · ₯ · ₹
+ * ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+ * Sîne klâwen durh die wolken sint geslagen,
  * @public
  */
 function iAmPublic() {}

--- a/test/fixture/es6.output-toc.md
+++ b/test/fixture/es6.output-toc.md
@@ -121,7 +121,10 @@ A protected function
 
 ## iAmPublic
 
-A public function
+A public function. This uses a sampling of UTF8 to make sure we're on board:
+¥ · £ · € · $ · ¢ · ₡ · ₢ · ₣ · ₤ · ₥ · ₦ · ₧ · ₨ · ₩ · ₪ · ₫ · ₭ · ₮ · ₯ · ₹
+ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+Sîne klâwen durh die wolken sint geslagen,
 
 ## execute
 

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -74,8 +74,8 @@
           "column": 0
         },
         "end": {
-          "line": 7,
-          "column": 4
+          "line": 5,
+          "column": 83
         }
       }
     },
@@ -104,7 +104,7 @@
           {
             "title": "param",
             "name": "$0.params",
-            "lineNumber": 6,
+            "lineNumber": 5,
             "type": {
               "type": "RestType"
             }
@@ -196,22 +196,22 @@
     ],
     "loc": {
       "start": {
-        "line": 9,
+        "line": 7,
         "column": 0
       },
       "end": {
-        "line": 13,
+        "line": 11,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 14,
+          "line": 12,
           "column": 0
         },
         "end": {
-          "line": 14,
+          "line": 12,
           "column": 34
         }
       }
@@ -234,17 +234,17 @@
           {
             "title": "param",
             "name": "$0.a",
-            "lineNumber": 14
+            "lineNumber": 12
           },
           {
             "title": "param",
             "name": "$0.b",
-            "lineNumber": 14
+            "lineNumber": 12
           },
           {
             "title": "param",
             "name": "$0.c",
-            "lineNumber": 14
+            "lineNumber": 12
           }
         ]
       }
@@ -356,22 +356,22 @@
     ],
     "loc": {
       "start": {
-        "line": 16,
+        "line": 14,
         "column": 0
       },
       "end": {
-        "line": 20,
+        "line": 18,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 21,
+          "line": 19,
           "column": 0
         },
         "end": {
-          "line": 21,
+          "line": 19,
           "column": 31
         }
       }
@@ -453,7 +453,7 @@
       {
         "title": "param",
         "name": "b",
-        "lineNumber": 21
+        "lineNumber": 19
       }
     ],
     "properties": [],
@@ -594,22 +594,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 23,
+        "line": 21,
         "column": 0
       },
       "end": {
-        "line": 25,
+        "line": 23,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 26,
+          "line": 24,
           "column": 0
         },
         "end": {
-          "line": 62,
+          "line": 60,
           "column": 1
         }
       }
@@ -685,22 +685,22 @@
           "tags": [],
           "loc": {
             "start": {
-              "line": 27,
+              "line": 25,
               "column": 2
             },
             "end": {
-              "line": 29,
+              "line": 27,
               "column": 5
             }
           },
           "context": {
             "loc": {
               "start": {
-                "line": 30,
+                "line": 28,
                 "column": 2
               },
               "end": {
-                "line": 30,
+                "line": 28,
                 "column": 18
               }
             }
@@ -794,22 +794,22 @@
           "tags": [],
           "loc": {
             "start": {
-              "line": 32,
+              "line": 30,
               "column": 2
             },
             "end": {
-              "line": 34,
+              "line": 32,
               "column": 5
             }
           },
           "context": {
             "loc": {
               "start": {
-                "line": 35,
+                "line": 33,
                 "column": 2
               },
               "end": {
-                "line": 37,
+                "line": 35,
                 "column": 3
               }
             }
@@ -907,22 +907,22 @@
           "tags": [],
           "loc": {
             "start": {
-              "line": 46,
+              "line": 44,
               "column": 2
             },
             "end": {
-              "line": 49,
+              "line": 47,
               "column": 5
             }
           },
           "context": {
             "loc": {
               "start": {
-                "line": 50,
+                "line": 48,
                 "column": 2
               },
               "end": {
-                "line": 52,
+                "line": 50,
                 "column": 3
               }
             }
@@ -986,22 +986,22 @@
           ],
           "loc": {
             "start": {
-              "line": 54,
+              "line": 52,
               "column": 2
             },
             "end": {
-              "line": 57,
+              "line": 55,
               "column": 5
             }
           },
           "context": {
             "loc": {
               "start": {
-                "line": 58,
+                "line": 56,
                 "column": 2
               },
               "end": {
-                "line": 61,
+                "line": 59,
                 "column": 3
               }
             }
@@ -1221,22 +1221,22 @@
           "tags": [],
           "loc": {
             "start": {
-              "line": 39,
+              "line": 37,
               "column": 2
             },
             "end": {
-              "line": 41,
+              "line": 39,
               "column": 5
             }
           },
           "context": {
             "loc": {
               "start": {
-                "line": 42,
+                "line": 40,
                 "column": 2
               },
               "end": {
-                "line": 44,
+                "line": 42,
                 "column": 3
               }
             }
@@ -1350,22 +1350,22 @@
     ],
     "loc": {
       "start": {
-        "line": 64,
+        "line": 62,
         "column": 0
       },
       "end": {
-        "line": 68,
+        "line": 66,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 69,
+          "line": 67,
           "column": 0
         },
         "end": {
-          "line": 69,
+          "line": 67,
           "column": 25
         }
       }
@@ -1610,22 +1610,22 @@
     ],
     "loc": {
       "start": {
-        "line": 71,
+        "line": 69,
         "column": 0
       },
       "end": {
-        "line": 76,
+        "line": 74,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 77,
+          "line": 75,
           "column": 0
         },
         "end": {
-          "line": 77,
+          "line": 75,
           "column": 23
         }
       }
@@ -1772,22 +1772,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 79,
+        "line": 77,
         "column": 0
       },
       "end": {
-        "line": 81,
+        "line": 79,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 82,
+          "line": 80,
           "column": 0
         },
         "end": {
-          "line": 82,
+          "line": 80,
           "column": 43
         }
       }
@@ -1799,7 +1799,7 @@
       {
         "title": "param",
         "name": "someParams",
-        "lineNumber": 82,
+        "lineNumber": 80,
         "type": {
           "type": "RestType"
         }
@@ -1883,22 +1883,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 84,
+        "line": 82,
         "column": 0
       },
       "end": {
-        "line": 86,
+        "line": 84,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 87,
+          "line": 85,
           "column": 0
         },
         "end": {
-          "line": 94,
+          "line": 92,
           "column": 1
         }
       }
@@ -1910,7 +1910,7 @@
       {
         "title": "param",
         "name": "someParams",
-        "lineNumber": 87,
+        "lineNumber": 85,
         "type": {
           "type": "RestType",
           "expression": {
@@ -1998,22 +1998,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 98,
+        "line": 96,
         "column": 0
       },
       "end": {
-        "line": 100,
+        "line": 98,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 101,
+          "line": 99,
           "column": 0
         },
         "end": {
-          "line": 101,
+          "line": 99,
           "column": 23
         }
       }
@@ -2110,22 +2110,22 @@
     ],
     "loc": {
       "start": {
-        "line": 105,
+        "line": 103,
         "column": 0
       },
       "end": {
-        "line": 108,
+        "line": 106,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 109,
+          "line": 107,
           "column": 0
         },
         "end": {
-          "line": 109,
+          "line": 107,
           "column": 36
         }
       }
@@ -2272,22 +2272,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 111,
+        "line": 109,
         "column": 0
       },
       "end": {
-        "line": 113,
+        "line": 111,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 114,
+          "line": 112,
           "column": 0
         },
         "end": {
-          "line": 116,
+          "line": 114,
           "column": 1
         }
       }
@@ -2386,22 +2386,22 @@
     ],
     "loc": {
       "start": {
-        "line": 126,
+        "line": 124,
         "column": 0
       },
       "end": {
-        "line": 129,
+        "line": 127,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 130,
+          "line": 128,
           "column": 0
         },
         "end": {
-          "line": 130,
+          "line": 128,
           "column": 26
         }
       }
@@ -2442,7 +2442,7 @@
           "children": [
             {
               "type": "text",
-              "value": "A public function",
+              "value": "A public function. This uses a sampling of UTF8 to make sure we're on board:\n¥ · £ · € · $ · ¢ · ₡ · ₢ · ₣ · ₤ · ₥ · ₦ · ₧ · ₨ · ₩ · ₪ · ₫ · ₭ · ₮ · ₯ · ₹\nᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ\nSîne klâwen durh die wolken sint geslagen,",
               "position": {
                 "start": {
                   "line": 1,
@@ -2450,11 +2450,15 @@
                   "offset": 0
                 },
                 "end": {
-                  "line": 1,
-                  "column": 18,
-                  "offset": 17
+                  "line": 4,
+                  "column": 43,
+                  "offset": 227
                 },
-                "indent": []
+                "indent": [
+                  1,
+                  1,
+                  1
+                ]
               }
             }
           ],
@@ -2465,11 +2469,15 @@
               "offset": 0
             },
             "end": {
-              "line": 1,
-              "column": 18,
-              "offset": 17
+              "line": 4,
+              "column": 43,
+              "offset": 227
             },
-            "indent": []
+            "indent": [
+              1,
+              1,
+              1
+            ]
           }
         }
       ],
@@ -2480,9 +2488,9 @@
           "offset": 0
         },
         "end": {
-          "line": 1,
-          "column": 18,
-          "offset": 17
+          "line": 4,
+          "column": 43,
+          "offset": 227
         }
       }
     },
@@ -2490,27 +2498,27 @@
       {
         "title": "public",
         "description": null,
-        "lineNumber": 2
+        "lineNumber": 5
       }
     ],
     "loc": {
       "start": {
-        "line": 132,
+        "line": 130,
         "column": 0
       },
       "end": {
-        "line": 135,
+        "line": 136,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 136,
+          "line": 137,
           "column": 0
         },
         "end": {
-          "line": 136,
+          "line": 137,
           "column": 23
         }
       }
@@ -2598,22 +2606,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 144,
+        "line": 145,
         "column": 0
       },
       "end": {
-        "line": 146,
+        "line": 147,
         "column": 3
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 147,
+          "line": 148,
           "column": 0
         },
         "end": {
-          "line": 147,
+          "line": 148,
           "column": 42
         }
       }
@@ -2698,22 +2706,22 @@
     "tags": [],
     "loc": {
       "start": {
-        "line": 149,
+        "line": 150,
         "column": 0
       },
       "end": {
-        "line": 149,
+        "line": 150,
         "column": 32
       }
     },
     "context": {
       "loc": {
         "start": {
-          "line": 150,
+          "line": 151,
           "column": 0
         },
         "end": {
-          "line": 156,
+          "line": 157,
           "column": 1
         }
       }
@@ -2725,7 +2733,7 @@
       {
         "title": "param",
         "name": "array1",
-        "lineNumber": 151,
+        "lineNumber": 152,
         "type": {
           "type": "TypeApplication",
           "expression": {
@@ -2743,7 +2751,7 @@
       {
         "title": "param",
         "name": "array2",
-        "lineNumber": 152,
+        "lineNumber": 153,
         "type": {
           "type": "TypeApplication",
           "expression": {

--- a/test/fixture/es6.output.md
+++ b/test/fixture/es6.output.md
@@ -144,7 +144,10 @@ A protected function
 
 ## iAmPublic
 
-A public function
+A public function. This uses a sampling of UTF8 to make sure we're on board:
+¥ · £ · € · $ · ¢ · ₡ · ₢ · ₣ · ₤ · ₥ · ₦ · ₧ · ₨ · ₩ · ₪ · ₫ · ₭ · ₮ · ₯ · ₹
+ᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ
+Sîne klâwen durh die wolken sint geslagen,
 
 ## execute
 

--- a/test/fixture/es6.output.md.json
+++ b/test/fixture/es6.output.md.json
@@ -1860,7 +1860,7 @@
       "children": [
         {
           "type": "text",
-          "value": "A public function",
+          "value": "A public function. This uses a sampling of UTF8 to make sure we're on board:\n¥ · £ · € · $ · ¢ · ₡ · ₢ · ₣ · ₤ · ₥ · ₦ · ₧ · ₨ · ₩ · ₪ · ₫ · ₭ · ₮ · ₯ · ₹\nᚠᛇᚻ᛫ᛒᛦᚦ᛫ᚠᚱᚩᚠᚢᚱ᛫ᚠᛁᚱᚪ᛫ᚷᛖᚻᚹᛦᛚᚳᚢᛗ\nSîne klâwen durh die wolken sint geslagen,",
           "position": {
             "start": {
               "line": 1,
@@ -1868,11 +1868,15 @@
               "offset": 0
             },
             "end": {
-              "line": 1,
-              "column": 18,
-              "offset": 17
+              "line": 4,
+              "column": 43,
+              "offset": 227
             },
-            "indent": []
+            "indent": [
+              1,
+              1,
+              1
+            ]
           }
         }
       ],
@@ -1883,11 +1887,15 @@
           "offset": 0
         },
         "end": {
-          "line": 1,
-          "column": 18,
-          "offset": 17
+          "line": 4,
+          "column": 43,
+          "offset": 227
         },
-        "indent": []
+        "indent": [
+          1,
+          1,
+          1
+        ]
       }
     },
     {


### PR DESCRIPTION
This guards against potential core errors like the one possibly found in #668 and makes sure
documentation.js continues to be UTF8 friendly