### PR TITLE
refactor(exported-extractor): Use Map object instead of Object.create

### DIFF
--- a/lib/extractors/exported.js
+++ b/lib/extractors/exported.js
@@ -28,7 +28,7 @@ function walkExported(
 ) {
   var newResults = [];
   var filename = data.file;
-  var dataCache = Object.create(null);
+  var dataCache = new Map();
 
   function addBlankComment(data, path, node) {
     return addComment(data, '', node.loc, path, node.loc, true);
@@ -178,7 +178,7 @@ function getCachedData(dataCache, filePath) {
     path = require.resolve(path);
   }
 
-  var value = dataCache[path];
+  var value = dataCache.get(path);
   if (!value) {
     var input = fs.readFileSync(path, 'utf-8');
     var ast = parseToAst(input, path);
@@ -189,7 +189,7 @@ function getCachedData(dataCache, filePath) {
       },
       ast
     };
-    dataCache[path] = value;
+    dataCache.set(path, value);
   }
   return value;
 }


### PR DESCRIPTION
The map object provides a cleaner and more predictable way to deal with indexed data in JavaScript.
I wrote something about that here http://www.macwright.org/2017/03/13/maps-not-strictly-better.html