### PR TITLE
refactor: Move index.js to lib

### DIFF
--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -1,9 +1,10 @@
 type DocumentationConfig = {
   polyglot?: boolean,
-  inferPrivate?: boolean,
+  inferPrivate?: string,
   noPackage?: boolean,
   toc?: Array<Object>,
   paths?: { [key: string]: number },
+  access?: Array<string>,
   defaultGlobals?: boolean,
   defaultGlobalsEnvs?: Array<string>,
   external?: Array<string>,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,29 +2,29 @@
 
 var fs = require('fs'),
   _ = require('lodash'),
-  sort = require('./lib/sort'),
-  nest = require('./lib/nest'),
-  filterAccess = require('./lib/filter_access'),
-  dependency = require('./lib/input/dependency'),
-  shallow = require('./lib/input/shallow'),
-  parseJavaScript = require('./lib/parsers/javascript'),
-  polyglot = require('./lib/parsers/polyglot'),
-  github = require('./lib/github'),
-  hierarchy = require('./lib/hierarchy'),
-  inferName = require('./lib/infer/name'),
-  inferKind = require('./lib/infer/kind'),
-  inferAugments = require('./lib/infer/augments'),
-  inferParams = require('./lib/infer/params'),
-  inferProperties = require('./lib/infer/properties'),
-  inferMembership = require('./lib/infer/membership'),
-  inferReturn = require('./lib/infer/return'),
-  inferAccess = require('./lib/infer/access'),
-  inferType = require('./lib/infer/type'),
-  formatLint = require('./lib/lint').formatLint,
-  garbageCollect = require('./lib/garbage_collect'),
-  lintComments = require('./lib/lint').lintComments,
-  markdownAST = require('./lib/output/markdown_ast'),
-  mergeConfig = require('./lib/merge_config');
+  sort = require('./sort'),
+  nest = require('./nest'),
+  filterAccess = require('./filter_access'),
+  dependency = require('./input/dependency'),
+  shallow = require('./input/shallow'),
+  parseJavaScript = require('./parsers/javascript'),
+  polyglot = require('./parsers/polyglot'),
+  github = require('./github'),
+  hierarchy = require('./hierarchy'),
+  inferName = require('./infer/name'),
+  inferKind = require('./infer/kind'),
+  inferAugments = require('./infer/augments'),
+  inferParams = require('./infer/params'),
+  inferProperties = require('./infer/properties'),
+  inferMembership = require('./infer/membership'),
+  inferReturn = require('./infer/return'),
+  inferAccess = require('./infer/access'),
+  inferType = require('./infer/type'),
+  formatLint = require('./lint').formatLint,
+  garbageCollect = require('./garbage_collect'),
+  lintComments = require('./lint').lintComments,
+  markdownAST = require('./output/markdown_ast'),
+  mergeConfig = require('./merge_config');
 
 /**
  * Build a pipeline of comment handlers.
@@ -45,7 +45,10 @@ function pipeline() {
   };
 }
 
-function configure(indexes, args) /*: Promise<InputsConfig> */ {
+function configure(
+  indexes /*: Array<string> */,
+  args /*: Object */
+) /*: Promise<InputsConfig> */ {
   let mergedConfig = mergeConfig(args);
 
   return mergedConfig.then(config => {
@@ -185,7 +188,8 @@ function lintInternal(inputsAndConfig) {
  *   }
  * });
  */
-let lint = (indexes, args) => configure(indexes, args).then(lintInternal);
+let lint = (indexes /*: Array<string|Object> */, args) =>
+  configure(indexes, args).then(lintInternal);
 
 /**
  * Generate JavaScript documentation as a list of parsed JSDoc
@@ -228,7 +232,8 @@ let lint = (indexes, args) => configure(indexes, args).then(lintInternal);
  *   // any other kind of code data.
  * });
  */
-let build = (indexes, args) => configure(indexes, args).then(buildInternal);
+let build = (indexes /*: Array<string|Object> */, args /*: Object */) =>
+  configure(indexes, args).then(buildInternal);
 
 /**
  * Documentation's formats are modular methods that take comments
@@ -238,11 +243,11 @@ let build = (indexes, args) => configure(indexes, args).then(buildInternal);
  * @public
  */
 var formats = {
-  html: require('./lib/output/html'),
-  md: require('./lib/output/markdown'),
+  html: require('./output/html'),
+  md: require('./output/markdown'),
   remark: (comments /*: Array<Comment> */, config /*: DocumentationConfig */) =>
     markdownAST(comments, config).then(res => JSON.stringify(res, null, 2)),
-  json: require('./lib/output/json')
+  json: require('./output/json')
 };
 
 module.exports.lint = lint;
@@ -251,6 +256,6 @@ module.exports.build = build;
 module.exports.formats = formats;
 
 module.exports.util = {
-  createFormatters: require('./lib/output/util/formatters'),
-  LinkerStack: require('./lib/output/util/linker_stack')
+  createFormatters: require('./output/util/formatters'),
+  LinkerStack: require('./output/util/linker_stack')
 };

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "website"
   ],
   "license": "ISC",
-  "main": "index.js",
+  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:documentationjs/documentation.git"
@@ -90,7 +90,7 @@
     "release": "standard-version",
     "precommit": "lint-staged --verbose",
     "format": "prettier --write '{lib,test}/**/*.js' --single-quote",
-    "doc": "./bin/documentation.js build index.js -f md --access=public > docs/NODE_API.md",
+    "doc": "./bin/documentation.js build lib/index.js -f md --access=public > docs/NODE_API.md",
     "changelog": "standard-changelog -i CHANGELOG.md -w",
     "self-lint": "node ./bin/documentation.js lint",
     "test": "are-we-flow-yet lib && flow check && npm run self-lint && npm run test-tap",


### PR DESCRIPTION
Moves index.js into lib, so it can be easily covered by our coverage tools, style linting, and so on.

Fixes https://github.com/documentationjs/documentation/issues/736