### PR TITLE
fix(html output): Fix github links in HTML output

### DIFF
--- a/default_theme/section._
+++ b/default_theme/section._
@@ -8,8 +8,8 @@
     </h3>
     <% } %>
     <% if (section.context && section.context.github) { %>
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='<%= section.context.github %>'>
-      <span><%= section.context.path %></span>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='<%= section.context.github.url %>'>
+      <span><%= section.context.github.path %></span>
       </a>
     <% } %>
   </div>


### PR DESCRIPTION
Fixes #738

Can't wait to switch off of lodash-style templates so this kind of thing can be caught by the type system.