### PR TITLE
fix(flow): Fix inference of Flow types with properties

### DIFF
--- a/lib/flow_doctrine.js
+++ b/lib/flow_doctrine.js
@@ -1,6 +1,8 @@
 'use strict';
 /* @flow */
 
+const generate = require('babel-generator').default;
+
 var namedTypes = {
   NumberTypeAnnotation: 'number',
   BooleanTypeAnnotation: 'boolean',
@@ -12,12 +14,6 @@ var oneToOne = {
   MixedTypeAnnotation: 'AllLiteral',
   NullLiteralTypeAnnotation: 'NullLiteral',
   VoidTypeAnnotation: 'VoidLiteral'
-};
-
-var literalTypes = {
-  BooleanLiteralTypeAnnotation: 'BooleanLiteralType',
-  NumericLiteralTypeAnnotation: 'NumericLiteralType',
-  StringLiteralTypeAnnotation: 'StringLiteralType'
 };
 
 function propertyToField(property) {
@@ -116,7 +112,9 @@ function flowDoctrine(type /*: Object */) /*: DoctrineType*/ {
           type: 'TypeApplication',
           expression: {
             type: 'NameExpression',
-            name: type.id.name
+            name: generate(type.id, {
+              compact: true
+            }).code
           },
           applications: type.typeParameters.params.map(flowDoctrine)
         };
@@ -124,7 +122,9 @@ function flowDoctrine(type /*: Object */) /*: DoctrineType*/ {
 
       return {
         type: 'NameExpression',
-        name: type.id.name
+        name: generate(type.id, {
+          compact: true
+        }).code
       };
 
     case 'ObjectTypeAnnotation':
@@ -137,20 +137,30 @@ function flowDoctrine(type /*: Object */) /*: DoctrineType*/ {
 
       return {
         type: 'NameExpression',
-        name: type.id.name
+        name: generate(type.id, {
+          compact: true
+        }).code
+      };
+    case 'BooleanLiteralTypeAnnotation':
+      return {
+        type: 'BooleanLiteralType',
+        value: type.value
+      };
+    case 'NumericLiteralTypeAnnotation':
+      return {
+        type: 'NumericLiteralType',
+        value: type.value
+      };
+    case 'StringLiteralTypeAnnotation':
+      return {
+        type: 'StringLiteralType',
+        value: type.value
+      };
+    default:
+      return {
+        type: 'AllLiteral'
       };
   }
-
-  if (type.type in literalTypes) {
-    return {
-      type: literalTypes[type.type],
-      value: type.value
-    };
-  }
-
-  return {
-    type: 'AllLiteral'
-  };
 }
 
 module.exports = flowDoctrine;

--- a/test/fixture/es6.input.js
+++ b/test/fixture/es6.input.js
@@ -154,3 +154,8 @@ export function isArrayEqualWith<T>(
 ): boolean {
   return true;
 }
+
+/** Regression check for #749 */
+export function paramWithMemberType(a: atype.property): boolean {
+  return true;
+}

--- a/test/fixture/es6.output-toc.md
+++ b/test/fixture/es6.output-toc.md
@@ -138,3 +138,13 @@ Regression check for #498
 -   `compareFunction` **function (a: T, b: T): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**  (optional, default `(a:T,b:T):boolean=>a===b`)
 
 Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+## paramWithMemberType
+
+Regression check for #749
+
+**Parameters**
+
+-   `a` **atype.property** 
+
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -2841,5 +2841,125 @@
       }
     ],
     "namespace": "isArrayEqualWith"
+  },
+  {
+    "description": {
+      "type": "root",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Regression check for #749",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 1,
+                  "offset": 0
+                },
+                "end": {
+                  "line": 1,
+                  "column": 26,
+                  "offset": 25
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 26,
+              "offset": 25
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 26,
+          "offset": 25
+        }
+      }
+    },
+    "tags": [],
+    "loc": {
+      "start": {
+        "line": 158,
+        "column": 0
+      },
+      "end": {
+        "line": 158,
+        "column": 32
+      }
+    },
+    "context": {
+      "loc": {
+        "start": {
+          "line": 159,
+          "column": 0
+        },
+        "end": {
+          "line": 161,
+          "column": 1
+        }
+      }
+    },
+    "augments": [],
+    "errors": [],
+    "examples": [],
+    "params": [
+      {
+        "title": "param",
+        "name": "a",
+        "lineNumber": 159,
+        "type": {
+          "type": "NameExpression",
+          "name": "atype.property"
+        }
+      }
+    ],
+    "properties": [],
+    "returns": [
+      {
+        "title": "returns",
+        "type": {
+          "type": "NameExpression",
+          "name": "boolean"
+        }
+      }
+    ],
+    "sees": [],
+    "throws": [],
+    "todos": [],
+    "name": "paramWithMemberType",
+    "kind": "function",
+    "members": {
+      "global": [],
+      "inner": [],
+      "instance": [],
+      "events": [],
+      "static": []
+    },
+    "path": [
+      {
+        "name": "paramWithMemberType",
+        "kind": "function"
+      }
+    ],
+    "namespace": "paramWithMemberType"
   }
 ]

--- a/test/fixture/es6.output.md
+++ b/test/fixture/es6.output.md
@@ -22,6 +22,7 @@
 -   [iAmPublic](#iampublic)
 -   [execute](#execute)
 -   [isArrayEqualWith](#isarrayequalwith)
+-   [paramWithMemberType](#paramwithmembertype)
 
 ## destructure
 
@@ -159,5 +160,15 @@ Regression check for #498
 -   `array1` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** 
 -   `array2` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** 
 -   `compareFunction` **function (a: T, b: T): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**  (optional, default `(a:T,b:T):boolean=>a===b`)
+
+Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+## paramWithMemberType
+
+Regression check for #749
+
+**Parameters**
+
+-   `a` **atype.property** 
 
 Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 

--- a/test/fixture/es6.output.md.json
+++ b/test/fixture/es6.output.md.json
@@ -2271,6 +2271,126 @@
           "value": " "
         }
       ]
+    },
+    {
+      "depth": 2,
+      "type": "heading",
+      "children": [
+        {
+          "type": "text",
+          "value": "paramWithMemberType"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Regression check for #749",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1,
+              "offset": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 26,
+              "offset": 25
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 26,
+          "offset": 25
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "strong",
+      "children": [
+        {
+          "type": "text",
+          "value": "Parameters"
+        }
+      ]
+    },
+    {
+      "ordered": false,
+      "type": "list",
+      "children": [
+        {
+          "type": "listItem",
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "inlineCode",
+                  "value": "a"
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                },
+                {
+                  "type": "strong",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "atype.property"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "value": " "
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Returns "
+        },
+        {
+          "type": "strong",
+          "children": [
+            {
+              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "type": "link",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "boolean"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": " "
+        }
+      ]
     }
   ]
 }

--- a/test/format_type.js
+++ b/test/format_type.js
@@ -22,6 +22,7 @@ test('formatType', function(t) {
     ['null', 'null'],
     ['null', 'null'],
     ['*', 'any'],
+    ['namedType.typeProperty', 'namedType.typeProperty'],
     [
       'Array|undefined',
       '([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) \\| [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined))'

--- a/test/lib/flow_doctrine.js
+++ b/test/lib/flow_doctrine.js
@@ -118,6 +118,105 @@ test('flowDoctrine', function(t) {
   );
 
   t.deepEqual(
+    toDoctrineType('namedType.propertyOfType'),
+    {
+      type: 'NameExpression',
+      name: 'namedType.propertyOfType'
+    },
+    'named type with property'
+  );
+
+  t.deepEqual(
+    toDoctrineType('Array<namedType.propertyOfType>'),
+    {
+      applications: [
+        {
+          type: 'NameExpression',
+          name: 'namedType.propertyOfType'
+        }
+      ],
+      expression: {
+        name: 'Array',
+        type: 'NameExpression'
+      },
+      type: 'TypeApplication'
+    },
+    'typeapplication of named type with property'
+  );
+
+  t.deepEqual(
+    toDoctrineType('Array<namedType.propertyOfType<boolean>>'),
+    {
+      applications: [
+        {
+          applications: [
+            {
+              name: 'boolean',
+              type: 'NameExpression'
+            }
+          ],
+          expression: {
+            type: 'NameExpression',
+            name: 'namedType.propertyOfType'
+          },
+          type: 'TypeApplication'
+        }
+      ],
+      expression: {
+        name: 'Array',
+        type: 'NameExpression'
+      },
+      type: 'TypeApplication'
+    },
+    'nested type application'
+  );
+
+  t.deepEqual(
+    toDoctrineType('{ a: foo.bar }'),
+    {
+      fields: [
+        {
+          key: 'a',
+          type: 'FieldType',
+          value: {
+            name: 'foo.bar',
+            type: 'NameExpression'
+          }
+        }
+      ],
+      type: 'RecordType'
+    },
+    'object type expression with subtype'
+  );
+
+  t.deepEqual(
+    toDoctrineType('{ a: { b: foo.bar } }'),
+    {
+      fields: [
+        {
+          key: 'a',
+          type: 'FieldType',
+          value: {
+            type: 'RecordType',
+            fields: [
+              {
+                key: 'b',
+                type: 'FieldType',
+                value: {
+                  name: 'foo.bar',
+                  type: 'NameExpression'
+                }
+              }
+            ]
+          }
+        }
+      ],
+      type: 'RecordType'
+    },
+    'nested fieldtype'
+  );
+
+  t.deepEqual(
     toDoctrineType('{ a: 1 }'),
     {
       type: 'RecordType',


### PR DESCRIPTION
Previously we naively thought that id.name would be a string for all types, which is not the case.
Instead, we use babel-generator to safely generate string representations of types.

Fixes #749