### PR TITLE
fix(params): Parameters with default use = not ?

### DIFF
--- a/lib/infer/params.js
+++ b/lib/infer/params.js
@@ -105,10 +105,7 @@ function paramToDoc(
         default: generate(param.right, {
           compact: true
         }).code,
-        type: {
-          type: 'OptionalType',
-          expression: newAssignmentParam.type
-        }
+        type: newAssignmentParam.type
       });
     // ObjectPattern <AssignmentProperty | RestElement>
     case 'ObjectPattern': // { a }
@@ -311,11 +308,7 @@ function combineTags(inferredTag, explicitTag) {
   var defaultValue;
   if (!explicitTag.type) {
     type = inferredTag.type;
-  } else if (explicitTag.type.type !== 'OptionalType' && inferredTag.default) {
-    type = {
-      type: 'OptionalType',
-      expression: explicitTag.type
-    };
+  } else if (!explicitTag.default && inferredTag.default) {
     defaultValue = inferredTag.default;
   }
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -252,6 +252,9 @@ var flatteners = {
 
     if (tag.default) {
       param.default = tag.default;
+      if (param.type && param.type.type === 'OptionalType') {
+        param.type = param.type.expression;
+      }
     }
 
     result.params.push(param);

--- a/test/fixture/es6.output-toc.md
+++ b/test/fixture/es6.output-toc.md
@@ -7,9 +7,9 @@ have any parameter descriptions.
 
 **Parameters**
 
--   `$0` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?**  (optional, default `{}`)
-    -   `$0.phoneNumbers` **any?**  (optional, default `[]`)
-    -   `$0.emailAddresses` **any?**  (optional, default `[]`)
+-   `$0` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
+    -   `$0.phoneNumbers`   (optional, default `[]`)
+    -   `$0.emailAddresses`   (optional, default `[]`)
     -   `$0.params` **...any** 
 
 ## destructure
@@ -111,7 +111,7 @@ This tests our support of optional parameters in ES6
 
 **Parameters**
 
--   `foo` **any?**  (optional, default `'bar'`)
+-   `foo`   (optional, default `'bar'`)
 
 ## iAmProtected
 
@@ -133,7 +133,7 @@ Regression check for #498
 
 -   `array1` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** 
 -   `array2` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** 
--   `compareFunction` **function (a: T, b: T): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**  (optional, default `(a:T,b:T):boolean=>a===b`)
+-   `compareFunction` **function (a: T, b: T): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `(a:T,b:T):boolean=>a===b`)
 
 Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 

--- a/test/fixture/es6.output.json
+++ b/test/fixture/es6.output.json
@@ -88,30 +88,21 @@
         "name": "$0",
         "anonymous": true,
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Object"
-          }
+          "type": "NameExpression",
+          "name": "Object"
         },
         "properties": [
           {
             "title": "param",
             "name": "$0.phoneNumbers",
             "lineNumber": 6,
-            "default": "[]",
-            "type": {
-              "type": "OptionalType"
-            }
+            "default": "[]"
           },
           {
             "title": "param",
             "name": "$0.emailAddresses",
             "lineNumber": 6,
-            "default": "[]",
-            "type": {
-              "type": "OptionalType"
-            }
+            "default": "[]"
           },
           {
             "title": "param",
@@ -2257,10 +2248,7 @@
         "title": "param",
         "name": "foo",
         "lineNumber": 112,
-        "default": "'bar'",
-        "type": {
-          "type": "OptionalType"
-        }
+        "default": "'bar'"
       }
     ],
     "properties": [],
@@ -2724,31 +2712,28 @@
         "name": "compareFunction",
         "lineNumber": 151,
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "FunctionType",
-            "params": [
-              {
-                "type": "ParameterType",
-                "name": "a",
-                "expression": {
-                  "type": "NameExpression",
-                  "name": "T"
-                }
-              },
-              {
-                "type": "ParameterType",
-                "name": "b",
-                "expression": {
-                  "type": "NameExpression",
-                  "name": "T"
-                }
+          "type": "FunctionType",
+          "params": [
+            {
+              "type": "ParameterType",
+              "name": "a",
+              "expression": {
+                "type": "NameExpression",
+                "name": "T"
               }
-            ],
-            "result": {
-              "type": "NameExpression",
-              "name": "boolean"
+            },
+            {
+              "type": "ParameterType",
+              "name": "b",
+              "expression": {
+                "type": "NameExpression",
+                "name": "T"
+              }
             }
+          ],
+          "result": {
+            "type": "NameExpression",
+            "name": "boolean"
           }
         },
         "default": "(a:T,b:T):boolean=>a===b"

--- a/test/fixture/es6.output.md
+++ b/test/fixture/es6.output.md
@@ -30,9 +30,9 @@ have any parameter descriptions.
 
 **Parameters**
 
--   `$0` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?**  (optional, default `{}`)
-    -   `$0.phoneNumbers` **any?**  (optional, default `[]`)
-    -   `$0.emailAddresses` **any?**  (optional, default `[]`)
+-   `$0` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)**  (optional, default `{}`)
+    -   `$0.phoneNumbers`   (optional, default `[]`)
+    -   `$0.emailAddresses`   (optional, default `[]`)
     -   `$0.params` **...any** 
 
 ## destructure
@@ -134,7 +134,7 @@ This tests our support of optional parameters in ES6
 
 **Parameters**
 
--   `foo` **any?**  (optional, default `'bar'`)
+-   `foo`   (optional, default `'bar'`)
 
 ## iAmProtected
 
@@ -156,7 +156,7 @@ Regression check for #498
 
 -   `array1` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** 
 -   `array2` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;T>** 
--   `compareFunction` **function (a: T, b: T): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)?**  (optional, default `(a:T,b:T):boolean=>a===b`)
+-   `compareFunction` **function (a: T, b: T): [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)**  (optional, default `(a:T,b:T):boolean=>a===b`)
 
 Returns **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 

--- a/test/fixture/es6.output.md.json
+++ b/test/fixture/es6.output.md.json
@@ -94,10 +94,6 @@
                           "value": "Object"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },
@@ -143,19 +139,6 @@
                           "value": " "
                         },
                         {
-                          "type": "strong",
-                          "children": [
-                            {
-                              "type": "text",
-                              "value": "any"
-                            },
-                            {
-                              "type": "text",
-                              "value": "?"
-                            }
-                          ]
-                        },
-                        {
                           "type": "text",
                           "value": " "
                         },
@@ -193,19 +176,6 @@
                         {
                           "type": "text",
                           "value": " "
-                        },
-                        {
-                          "type": "strong",
-                          "children": [
-                            {
-                              "type": "text",
-                              "value": "any"
-                            },
-                            {
-                              "type": "text",
-                              "value": "?"
-                            }
-                          ]
                         },
                         {
                           "type": "text",
@@ -1808,19 +1778,6 @@
                   "value": " "
                 },
                 {
-                  "type": "strong",
-                  "children": [
-                    {
-                      "type": "text",
-                      "value": "any"
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
-                    }
-                  ]
-                },
-                {
                   "type": "text",
                   "value": " "
                 },
@@ -2199,10 +2156,6 @@
                           "value": "boolean"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },

--- a/test/fixture/html/nested.config-output.html
+++ b/test/fixture/html/nested.config-output.html
@@ -457,7 +457,7 @@ the referenced class type</p>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>isBuffer(buf, size = 0)</span>
+            <span class='code strong strong truncate'>isBuffer(buf, size)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -468,7 +468,7 @@ the referenced class type</p>
   <p>This method takes a Buffer object that will be linked to nodejs.org</p>
 
 
-  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
   
   
 
@@ -493,7 +493,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>size</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?
+            <span class='code bold'>size</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
             = <code>0</code>)</code>
 	    size
 

--- a/test/fixture/html/nested.output.files
+++ b/test/fixture/html/nested.output.files
@@ -419,7 +419,7 @@ the referenced class type</p>
       <div class="clearfix small pointer toggle-sibling">
         <div class="py1 contain">
             <a class='icon pin-right py1 dark-link caret-right'>▸</a>
-            <span class='code strong strong truncate'>isBuffer(buf, size = 0)</span>
+            <span class='code strong strong truncate'>isBuffer(buf, size)</span>
         </div>
       </div>
       <div class="clearfix display-none toggle-target">
@@ -430,7 +430,7 @@ the referenced class type</p>
   <p>This method takes a Buffer object that will be linked to nodejs.org</p>
 
 
-  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href="https://nodejs.org/api/buffer.html">Buffer</a> | <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>), size: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean">boolean</a></div>
   
   
 
@@ -455,7 +455,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>size</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>?
+            <span class='code bold'>size</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number">number</a>
             = <code>0</code>)</code>
 	    size
 

--- a/test/fixture/nest_params.output.json
+++ b/test/fixture/nest_params.output.json
@@ -333,11 +333,8 @@
           }
         },
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "string"
-          }
+          "type": "NameExpression",
+          "name": "string"
         },
         "default": "minion"
       }

--- a/test/fixture/nest_params.output.md
+++ b/test/fixture/nest_params.output.md
@@ -12,7 +12,7 @@
 -   `employees` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** The employees who are responsible for the project.
     -   `employees[].name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of an employee.
     -   `employees[].department` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The employee's department.
--   `type` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** The employee's type. (optional, default `minion`)
+-   `type` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The employee's type. (optional, default `minion`)
 
 ## foo
 

--- a/test/fixture/nest_params.output.md.json
+++ b/test/fixture/nest_params.output.md.json
@@ -299,10 +299,6 @@
                           "value": "string"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },

--- a/test/fixture/params.output.json
+++ b/test/fixture/params.output.json
@@ -507,11 +507,8 @@
         "name": "x",
         "lineNumber": 2,
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "number"
-          }
+          "type": "NameExpression",
+          "name": "number"
         },
         "default": "2"
       }
@@ -1340,11 +1337,8 @@
           }
         },
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "number"
-          }
+          "type": "NameExpression",
+          "name": "number"
         },
         "default": "8"
       },
@@ -1470,11 +1464,8 @@
           }
         },
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "Array"
-          }
+          "type": "NameExpression",
+          "name": "Array"
         },
         "default": "[1]"
       }
@@ -1891,11 +1882,8 @@
               }
             },
             "type": {
-              "type": "OptionalType",
-              "expression": {
-                "type": "NameExpression",
-                "name": "number"
-              }
+              "type": "NameExpression",
+              "name": "number"
             },
             "default": "14"
           },
@@ -2213,11 +2201,8 @@
           }
         },
         "type": {
-          "type": "OptionalType",
-          "expression": {
-            "type": "NameExpression",
-            "name": "number"
-          }
+          "type": "NameExpression",
+          "name": "number"
         },
         "default": "123"
       }

--- a/test/fixture/params.output.md
+++ b/test/fixture/params.output.md
@@ -45,7 +45,7 @@ This method has a type in the description and a default in the code
 
 **Parameters**
 
--   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?**  (optional, default `2`)
+-   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)**  (optional, default `2`)
 
 ## Foo
 
@@ -80,9 +80,9 @@ This tests  our support of optional parameters
 **Parameters**
 
 -   `address` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** An IPv6 address string
--   `groups` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** How many octets to parse (optional, default `8`)
+-   `groups` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** How many octets to parse (optional, default `8`)
 -   `third` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** A third argument
--   `foo` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** to properly be parsed (optional, default `[1]`)
+-   `foo` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)** to properly be parsed (optional, default `[1]`)
 
 **Examples**
 
@@ -101,7 +101,7 @@ This tests our support of nested parameters
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** optional options
     -   `options.data` **([Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) \| [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** A GeoJSON data object or URL to it.
         The latter is preferable in case of large GeoJSON files.
-    -   `options.maxzoom` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Maximum zoom to preserve detail at. (optional, default `14`)
+    -   `options.maxzoom` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Maximum zoom to preserve detail at. (optional, default `14`)
     -   `options.buffer` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Tile buffer on each side.
     -   `options.tolerance` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** Simplification tolerance (higher means simpler).
 
@@ -112,7 +112,7 @@ values specified in code.
 
 **Parameters**
 
--   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?** an argument (optional, default `123`)
+-   `x` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** an argument (optional, default `123`)
 
 Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** some
 

--- a/test/fixture/params.output.md.json
+++ b/test/fixture/params.output.md.json
@@ -576,10 +576,6 @@
                           "value": "number"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },
@@ -1108,10 +1104,6 @@
                           "value": "number"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },
@@ -1279,10 +1271,6 @@
                           "value": "Array"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },
@@ -1661,10 +1649,6 @@
                                   "value": "number"
                                 }
                               ]
-                            },
-                            {
-                              "type": "text",
-                              "value": "?"
                             }
                           ]
                         },
@@ -1977,10 +1961,6 @@
                           "value": "number"
                         }
                       ]
-                    },
-                    {
-                      "type": "text",
-                      "value": "?"
                     }
                   ]
                 },

--- a/test/lib/infer/params.js
+++ b/test/lib/infer/params.js
@@ -270,10 +270,7 @@ test('inferParams', function(t) {
         name: 'x',
         title: 'param',
         lineNumber: 3,
-        type: {
-          expression: null,
-          type: 'OptionalType'
-        }
+        type: null
       }
     ],
     'default params'
@@ -295,11 +292,8 @@ test('inferParams', function(t) {
         title: 'param',
         lineNumber: 1,
         type: {
-          expression: {
-            type: 'NameExpression',
-            name: 'number'
-          },
-          type: 'OptionalType'
+          type: 'NameExpression',
+          name: 'number'
         }
       }
     ],


### PR DESCRIPTION
* Corrects infer/params to avoid marking parameters with default as optional
* Uses lib/parse to 'massage' doctrine's optional parameters into normal parameters with default values.

Do you think this is the correct approach, or should it be handled on the output side?

Fixes #737