### PR TITLE
Included nest module to the lint documentation.

### DIFF
--- a/__tests__/lib/lint.js
+++ b/__tests__/lib/lint.js
@@ -31,6 +31,14 @@ test('lintComments', function() {
   expect(
     evaluate(function() {
       /**
+      * @param {Object} foo.bar
+      */
+    }).errors
+  ).toEqual([{ commentLineNumber: 1, message: 'Parent of foo.bar not found' }]);
+
+  expect(
+    evaluate(function() {
+      /**
    * @param {String} foo
    * @param {array} bar
    */

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -71,7 +71,6 @@ type Comment = {
   tags: Array<CommentTag>,
 
   augments: Array<CommentTag>,
-  errors: Array<CommentExample>,
   examples: Array<CommentExample>,
   params: Array<CommentTag>,
   properties: Array<CommentTag>,

--- a/src/lint.js
+++ b/src/lint.js
@@ -4,6 +4,7 @@ var VFile = require('vfile');
 import { walk } from './walk';
 import vfileSort from 'vfile-sort';
 import reporter from 'vfile-reporter';
+import nest from './nest';
 
 var CANONICAL = {
   String: 'string',
@@ -27,11 +28,8 @@ function lintComments(comment: Comment) {
     function nameInvariant(name) {
       if (name && typeof CANONICAL[name] === 'string') {
         comment.errors.push({
-          message: 'type ' +
-            name +
-            ' found, ' +
-            CANONICAL[name] +
-            ' is standard',
+          message:
+            'type ' + name + ' found, ' + CANONICAL[name] + ' is standard',
           commentLineNumber: tag.lineNumber
         });
       }
@@ -60,6 +58,8 @@ function lintComments(comment: Comment) {
       checkCanonical(tag.type);
     }
   });
+  nest(comment);
+
   return comment;
 }
 


### PR DESCRIPTION
Check on parent element: foo.bar sub-parametr should be documeted with parent.
Fixed #832 issue