### PR TITLE
Add support for converting flow’s ThisTypeAnnotation to a doctrine NameExpression

### DIFF
--- a/__tests__/lib/flow_doctrine.js
+++ b/__tests__/lib/flow_doctrine.js
@@ -295,11 +295,15 @@ test('flowDoctrine', function() {
     type: 'VoidLiteral'
   });
 
+  expect(toDoctrineType('this')).toEqual({
+    type: 'NameExpression',
+    name: 'this'
+  });
+
   // TODO: remove all these types
   expect(types).toEqual([
     'IntersectionTypeAnnotation',
     'EmptyTypeAnnotation',
-    'ThisTypeAnnotation',
     'TypeofTypeAnnotation'
   ]);
 });

--- a/src/flow_doctrine.js
+++ b/src/flow_doctrine.js
@@ -152,6 +152,11 @@ function flowDoctrine(type: Object): DoctrineType {
         type: 'StringLiteralType',
         value: type.value
       };
+    case 'ThisTypeAnnotation':
+      return {
+        type: 'NameExpression',
+        name: 'this'
+      };
     default:
       return {
         type: 'AllLiteral'


### PR DESCRIPTION
Without this, class methods that return `this` were showing up in generated output as returning `any`.