### PR TITLE
style: Avoid optional parameter syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,4 @@
 {
-  "presets": ["flow"],
-  "plugins": [
-    ["transform-es2015-modules-commonjs", {
-      "allowTopLevelThis": true
-    }]
-  ]
+  "presets": ["es2015", "stage-0", "flow"],
+  "plugins": ["syntax-async-functions"]
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 7
+    version: 4
 test:
   override:
     - npm run test-ci

--- a/docs/NODE_API.md
+++ b/docs/NODE_API.md
@@ -105,7 +105,7 @@ Formats documentation as HTML.
 **Parameters**
 
 -   `comments` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Comment](https://developer.mozilla.org/en-US/docs/Web/API/Comment/Comment)>** parsed comments
--   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output (optional, default `{}`)
+-   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output
     -   `config.theme` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of a module used for an HTML theme. (optional, default `'default_theme'`)
 
 **Examples**
@@ -132,7 +132,7 @@ Formats documentation as
 **Parameters**
 
 -   `comments` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** parsed comments
--   `args` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output (optional, default `{}`)
+-   `args` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output
 
 **Examples**
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.1",
+    "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
     "babel-preset-flow": "^6.23.0",
     "chdir": "0.0.0",
@@ -79,6 +80,7 @@
     "mock-fs": "^4.2.0",
     "p-event": "^1.0.0",
     "prettier": "^1.0.0",
+    "regenerator-runtime": "^0.10.5",
     "standard-version": "^4.0.0",
     "tmp": "^0.0.31"
   },

--- a/src/output/html.js
+++ b/src/output/html.js
@@ -23,7 +23,10 @@ var mergeConfig = require('../merge_config');
  *     streamArray(output).pipe(vfs.dest('./output-directory'));
  *   });
  */
-function html(comments: Array<Comment>, config: Object = {}) {
+function html(comments: Array<Comment>, config?: Object) {
+  if (!config) {
+    config = {};
+  }
   return mergeConfig(config).then((config: DocumentationConfig) => {
     var themePath = '../default_theme/';
     if (config.theme) {

--- a/src/output/markdown.js
+++ b/src/output/markdown.js
@@ -23,10 +23,10 @@ var remark = require('remark'),
  *     fs.writeFileSync('./output.md', output);
  *   });
  */
-function markdown(
-  comments: Array<Comment>,
-  args: Object = {}
-): Promise<string> {
+function markdown(comments: Array<Comment>, args?: Object): Promise<string> {
+  if (!args) {
+    args = {};
+  }
   return markdownAST(comments, args).then(ast => remark().stringify(ast));
 }
 


### PR DESCRIPTION
Supporting this syntax uncorks a whole bottle of worms and requires participation in more of the
JavaScript ecosystem and is not worthwhile in my opinion at this time.

Fixes #873