### PR TITLE
Making return type params consistent with the rest of the code base

### DIFF
--- a/src/commands/readme.js
+++ b/src/commands/readme.js
@@ -49,7 +49,7 @@ module.exports.builder = {
  * Insert API documentation into a Markdown readme
  * @private
  * @param {Object} argv args from the CLI option parser
- * @return {undefined} has the side-effect of writing a file or printing to stdout
+ * @returns {undefined} has the side-effect of writing a file or printing to stdout
  */
 module.exports.handler = function readme(argv: Object) {
   argv._handled = true;

--- a/src/default_theme/assets/anchor.js
+++ b/src/default_theme/assets/anchor.js
@@ -49,7 +49,7 @@
     /**
      * Checks to see if this device supports touch. Uses criteria pulled from Modernizr:
      * https://github.com/Modernizr/Modernizr/blob/da22eb27631fc4957f67607fe6042e85c0a84656/feature-detects/touchevents.js#L40
-     * @return {Boolean} - true if the current device supports touch.
+     * @returns {Boolean} - true if the current device supports touch.
      */
     this.isTouchDevice = function() {
       return !!(
@@ -62,7 +62,7 @@
      * Add anchor links to page elements.
      * @param  {String|Array|Nodelist} selector - A CSS selector for targeting the elements you wish to add anchor links
      *                                            to. Also accepts an array or nodeList containing the relavant elements.
-     * @return {this}                           - The AnchorJS object
+     * @returns {this}                           - The AnchorJS object
      */
     this.add = function(selector) {
       var elements,
@@ -191,7 +191,7 @@
      * Removes all anchorjs-links from elements targed by the selector.
      * @param  {String|Array|Nodelist} selector - A CSS selector string targeting elements with anchor links,
      *                                            OR a nodeList / array containing the DOM elements.
-     * @return {this}                           - The AnchorJS object
+     * @returns {this}                           - The AnchorJS object
      */
     this.remove = function(selector) {
       var index,
@@ -227,7 +227,7 @@
      * remove extra hyphens, truncate, trim hyphens, and make lowercase.
      *
      * @param  {String} text - Any text. Usually pulled from the webpage element we are linking to.
-     * @return {String}      - hyphen-delimited text for use in IDs and URLs.
+     * @returns {String}      - hyphen-delimited text for use in IDs and URLs.
      */
     this.urlify = function(text) {
       // Regex for finding the nonsafe URL characters (many need escaping): & +$,:;=?@"#{}|^~[`%!'<>]./()*\
@@ -258,7 +258,7 @@
      * Determines if this element already has an AnchorJS link on it.
      * Uses this technique: http://stackoverflow.com/a/5898748/1154642
      * @param    {HTMLElemnt}  el - a DOM node
-     * @return   {Boolean}     true/false
+     * @returns   {Boolean}     true/false
      */
     this.hasAnchorJSLink = function(el) {
       var hasLeftAnchor =
@@ -276,7 +276,7 @@
      * It also throws errors on any other inputs. Used to handle inputs to .add and .remove.
      * @param  {String|Array|Nodelist} input - A CSS selector string targeting elements with anchor links,
      *                                         OR a nodeList / array containing the DOM elements.
-     * @return {Array} - An array containing the elements we want.
+     * @returns {Array} - An array containing the elements we want.
      */
     function _getElements(input) {
       var elements;

--- a/src/extractors/comments.js
+++ b/src/extractors/comments.js
@@ -35,7 +35,7 @@ function walkComments(
        * Parse a comment with doctrine and decorate the result with file position and code context.
        *
        * @param {Object} comment the current state of the parsed JSDoc comment
-       * @return {undefined} this emits data
+       * @returns {undefined} this emits data
        */
       function parseComment(comment) {
         newResults.push(

--- a/src/filter_access.js
+++ b/src/filter_access.js
@@ -9,7 +9,7 @@ import { walk } from './walk';
  *
  * @param {Array<string>} [levels=['public', 'undefined', 'protected']] included access levels.
  * @param {Array<Object>} comments parsed comments (can be nested)
- * @return {Array<Object>} filtered comments
+ * @returns {Array<Object>} filtered comments
  */
 function filterAccess(levels: Array<string>, comments: Array<Comment>) {
   function filter(comment) {

--- a/src/github.js
+++ b/src/github.js
@@ -9,7 +9,7 @@ var getGithubURLPrefix = require('./git/url_prefix');
  *
  * @name linkGitHub
  * @param {Object} comment parsed comment
- * @return {Object} comment with github inferred
+ * @returns {Object} comment with github inferred
  */
 module.exports = function(comment: Comment) {
   var repoPath = findGit(comment.context.file);

--- a/src/input/shallow.js
+++ b/src/input/shallow.js
@@ -16,7 +16,7 @@ var smartGlob = require('../smart_glob.js');
  *
  * @param indexes entry points
  * @param config parsing options
- * @return promise with parsed files
+ * @returns promise with parsed files
  */
 module.exports = function(
   indexes: Array<string | Object>,

--- a/src/is_jsdoc_comment.js
+++ b/src/is_jsdoc_comment.js
@@ -10,7 +10,7 @@
  *
  * @name isJSDocComment
  * @param {Object} comment an ast path of the comment
- * @return {boolean} whether it is valid
+ * @returns {boolean} whether it is valid
  */
 module.exports = function isJSDocComment(
   comment /*: {

--- a/src/lint.js
+++ b/src/lint.js
@@ -67,7 +67,7 @@ function lintComments(comment: Comment) {
  * @private
  * Extract lint instructions from comments and generate user-readable output.
  * @param {Array<Object>} comments a list of comments
- * @return {string} user-readable output
+ * @returns {string} user-readable output
  */
 function formatLint(comments: Array<Comment>): string {
   var vFiles = {};

--- a/src/module_filters.js
+++ b/src/module_filters.js
@@ -25,7 +25,7 @@ module.exports = {
    * @param {Object} options - An options object with `external` being a
    * micromatch-compaitible glob. *NOTE:* the glob will be matched relative to
    * the top-level node_modules directory for each entry point.
-   * @return {function} - A function for use as the module-deps `postFilter`
+   * @returns {function} - A function for use as the module-deps `postFilter`
    * options.
    */
   externals: function externalModuleFilter(

--- a/src/nest.js
+++ b/src/nest.js
@@ -95,7 +95,7 @@ var nestTag = (
  * This assumes that incoming comments have been flattened.
  *
  * @param {Object} comment input comment
- * @return {Object} nested comment
+ * @returns {Object} nested comment
  */
 var nest = (comment: Comment) =>
   Object.assign(comment, {

--- a/src/output/markdown.js
+++ b/src/output/markdown.js
@@ -10,7 +10,7 @@ var remark = require('remark'),
  * @param {Array<Object>} comments parsed comments
  * @param {Object} args Options that can customize the output
  * @name formats.markdown
- * @return {Promise<string>} a promise of the eventual value
+ * @returns {Promise<string>} a promise of the eventual value
  * @public
  * @example
  * var documentation = require('documentation');

--- a/src/parse.js
+++ b/src/parse.js
@@ -564,7 +564,7 @@ function flattenKindShorthand(result, tag, key) {
  * @param {string} comment input to be parsed
  * @param {Object} loc location of the input
  * @param {Object} context code context of the input
- * @return {Comment} an object conforming to the
+ * @returns {Comment} an object conforming to the
  * [documentation schema](https://github.com/documentationjs/api-json)
  */
 function parseJSDoc(comment: string, loc: ?Object, context: ?Object): Comment {

--- a/src/parsers/javascript.js
+++ b/src/parsers/javascript.js
@@ -32,7 +32,7 @@ function leftPad(str, width) {
  *
  * @param {Object} data a chunk of data provided by module-deps
  * @param {Object} config config
- * @return {Array<Object>} an array of parsed comments
+ * @returns {Array<Object>} an array of parsed comments
  */
 function parseJavaScript(data: Object, config: DocumentationConfig) {
   var visited = new Set();

--- a/src/sort.js
+++ b/src/sort.js
@@ -11,7 +11,7 @@ var fs = require('fs');
  *
  * @param {Array<Object>} comments all comments
  * @param {Object} options options from documentation.yml
- * @return {number} sorting value
+ * @returns {number} sorting value
  * @private
  */
 module.exports = function sortDocs(comments: Array<Comment>, options: Object) {


### PR DESCRIPTION
For consistency purposes makes sense to use the same tag for defining return values.