### PR TITLE
feat: implement @hideconstructor

### DIFF
--- a/__tests__/lib/infer/params.js
+++ b/__tests__/lib/infer/params.js
@@ -163,4 +163,28 @@ test('inferParams', function() {
   expect(
     evaluate('/** Test */ export default function f(x) {}').params
   ).toEqual([{ lineNumber: 1, name: 'x', title: 'param' }]);
+
+  expect(
+    evaluate(function() {
+      /**
+       * @class
+       * @hideconstructor
+       */
+      function SomeClass(foo, bar) {}
+    }).params
+  ).toEqual([]);
+
+  expect(
+    evaluate(`
+      /**
+       * Test
+       */
+      class SomeClass {
+        /**
+         * @hideconstructor
+         */
+        constructor(foo, bar) {}
+      }
+    `).params
+  ).toEqual([]);
 });

--- a/__tests__/lib/parse.js
+++ b/__tests__/lib/parse.js
@@ -444,6 +444,14 @@ test('parse - @global', function() {
   ).toBe('global');
 });
 
+test('parse - @hideconstructor', function() {
+  expect(
+    evaluate(function() {
+      /** @hideconstructor */
+    })[0].hideconstructor
+  ).toBe(true);
+});
+
 test('parse - @host', function() {});
 
 test('parse - @ignore', function() {

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -84,6 +84,7 @@ type Comment = {
   classdesc?: Remark,
 
   members: CommentMembers,
+  constructorComment?: Comment,
 
   name?: string,
   kind?: Kind,
@@ -100,6 +101,7 @@ type Comment = {
   since?: string,
   lends?: string,
   override?: boolean,
+  hideconstructor?: true,
 
   type?: DoctrineType,
 

--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -23,7 +23,10 @@ function inferParams(comment: Comment) {
 
   // If this is an ES6 class with a constructor method, infer
   // parameters from that constructor method.
-  if (t.isClassDeclaration(path)) {
+  if (
+    t.isClassDeclaration(path) &&
+    !(comment.constructorComment && comment.constructorComment.hideconstructor)
+  ) {
     let constructor = path.node.body.body.find(item => {
       // https://github.com/babel/babylon/blob/master/ast/spec.md#classbody
       return t.isClassMethod(item) && item.kind === 'constructor';
@@ -34,6 +37,10 @@ function inferParams(comment: Comment) {
   }
 
   if (!t.isFunction(path)) {
+    return comment;
+  }
+
+  if (comment.kind === 'class' && comment.hideconstructor) {
     return comment;
   }
 
@@ -277,7 +284,9 @@ function mergeTopNodes(inferred, explicit) {
 
   var errors = explicitTagsWithoutInference.map(tag => {
     return {
-      message: `An explicit parameter named ${tag.name || ''} was specified but didn't match ` +
+      message:
+        `An explicit parameter named ${tag.name ||
+          ''} was specified but didn't match ` +
         `inferred information ${Array.from(inferredNames).join(', ')}`,
       commentLineNumber: tag.lineNumber
     };

--- a/src/parse.js
+++ b/src/parse.js
@@ -168,6 +168,7 @@ var flatteners = {
   global(result) {
     result.scope = 'global';
   },
+  hideconstructor: flattenBoolean,
   host: synonym('external'),
   ignore: flattenBoolean,
   implements: todo,


### PR DESCRIPTION
[Per usejsdoc.org](http://usejsdoc.org/tags-hideconstructor.html), this tag goes either in a comment attached to a function that has declared that function to be a class, or in a comment on an ES6 class constructor.

This is relevant to the discussion in #689.