### PR TITLE
HTML output: Display all levels of parameter properties.

### DIFF
--- a/__tests__/__snapshots__/bin.js.snap
+++ b/__tests__/__snapshots__/bin.js.snap
@@ -97,6 +97,12 @@ exports[`--config 1`] = `
                         #withOptions
                       </a></li>
                       
+                      <li><a
+                        href='#klasswithdeepoptions'
+                        class='regular pre-open'>
+                        #withDeepOptions
+                      </a></li>
+                      
                     </ul>
                   
                   
@@ -773,16 +779,20 @@ k.isArrayOfBuffers();</pre>
             <tbody class='mt1'>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
               
             </tbody>
           </table>
@@ -794,6 +804,107 @@ k.isArrayOfBuffers();</pre>
             <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</code>
 	    
           </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='klasswithdeepoptions'>
+      <div class=\\"clearfix small pointer toggle-sibling\\">
+        <div class=\\"py1 contain\\">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>withDeepOptions(options)</span>
+        </div>
+      </div>
+      <div class=\\"clearfix display-none toggle-target\\">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>A function with a deep options parameter</p>
+
+
+  <div class='pre p1 fill-light mt0'>withDeepOptions(options: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+	    
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.bar.buz</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+  
+
+
+              
+            </tbody>
+          </table>
           
         </div>
       

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -890,6 +890,12 @@ exports[`html nested.input.js 1`] = `
                         #withOptions
                       </a></li>
                       
+                      <li><a
+                        href='#klasswithdeepoptions'
+                        class='regular pre-open'>
+                        #withDeepOptions
+                      </a></li>
+                      
                     </ul>
                   
                   
@@ -1538,16 +1544,20 @@ k.isArrayOfBuffers();</pre>
             <tbody class='mt1'>
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
               
                 <tr>
-                  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
-                  </td>
-                  <td class='break-word'><span></span></td>
-                </tr>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
               
             </tbody>
           </table>
@@ -1559,6 +1569,107 @@ k.isArrayOfBuffers();</pre>
             <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</code>
 	    
           </div>
+          
+        </div>
+      
+    </div>
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+</section>
+
+      </div>
+    </div>
+  
+    <div class='border-bottom' id='klasswithdeepoptions'>
+      <div class=\\"clearfix small pointer toggle-sibling\\">
+        <div class=\\"py1 contain\\">
+            <a class='icon pin-right py1 dark-link caret-right'>▸</a>
+            <span class='code strong strong truncate'>withDeepOptions(options)</span>
+        </div>
+      </div>
+      <div class=\\"clearfix display-none toggle-target\\">
+        <section class='p2 mb2 clearfix bg-white minishadow'>
+
+  
+
+  <p>A function with a deep options parameter</p>
+
+
+  <div class='pre p1 fill-light mt0'>withDeepOptions(options: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</div>
+  
+  
+
+  
+  
+  
+  
+  
+  
+
+  
+    <div class='py1 quiet mt1 prose-big'>Parameters</div>
+    <div class='prose'>
+      
+        <div class='space-bottom0'>
+          <div>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+	    
+          </div>
+          
+          <table class='mt1 mb2 fixed-table h5 col-12'>
+            <colgroup>
+              <col width='30%' />
+              <col width='70%' />
+            </colgroup>
+            <thead>
+              <tr class='bold fill-light'>
+                <th>Name</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody class='mt1'>
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+              
+                <tr>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+  
+    <tr>
+  <td class='break-word'><span class='code bold'>options.bar.buz</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  </td>
+  <td class='break-word'><span></span></td>
+</tr>
+
+
+  
+
+
+              
+            </tbody>
+          </table>
           
         </div>
       

--- a/__tests__/fixture/html/nested.input.js
+++ b/__tests__/fixture/html/nested.input.js
@@ -27,6 +27,15 @@ Klass.prototype.getFoo = function() {
 Klass.prototype.withOptions = function(options, otherOptions) {};
 
 /**
+ * A function with a deep options parameter
+ * @param {Object} options
+ * @param {string} options.foo
+ * @param {Object} options.bar
+ * @param {string} options.bar.buz
+ */
+Klass.prototype.withDeepOptions = function(options) {};
+
+/**
  * @typedef CustomError
  * @name CustomError
  * @description a typedef with nested properties

--- a/src/default_theme/index._
+++ b/src/default_theme/index._
@@ -97,7 +97,8 @@
             <%= renderSection({
               section: s,
               renderSection: renderSection,
-              renderSectionList: renderSectionList
+              renderSectionList: renderSectionList,
+              renderParamProperty: renderParamProperty
             }) %>
           <% } else { %>
             <div class='keyline-top-not py2'><%=renderNote({ note: s })%></div>

--- a/src/default_theme/index.js
+++ b/src/default_theme/index.js
@@ -22,12 +22,13 @@ module.exports = function(
   comments: Array<Comment>,
   config: DocumentationConfig
 ) {
-  var linkerStack = new LinkerStack(
-    config
-  ).namespaceResolver(comments, function(namespace) {
-    var slugger = new GithubSlugger();
-    return '#' + slugger.slug(namespace);
-  });
+  var linkerStack = new LinkerStack(config).namespaceResolver(
+    comments,
+    function(namespace) {
+      var slugger = new GithubSlugger();
+      return '#' + slugger.slug(namespace);
+    }
+  );
 
   var formatters = createFormatters(linkerStack.link);
 
@@ -96,6 +97,10 @@ module.exports = function(
   );
   sharedImports.imports.renderNote = _.template(
     fs.readFileSync(path.join(__dirname, 'note._'), 'utf8'),
+    sharedImports
+  );
+  sharedImports.imports.renderParamProperty = _.template(
+    fs.readFileSync(path.join(__dirname, 'paramProperty._'), 'utf8'),
     sharedImports
   );
 

--- a/src/default_theme/paramProperty._
+++ b/src/default_theme/paramProperty._
@@ -4,12 +4,12 @@
     (default <code><%- property.default %></code>)
   <% } %></td>
   <td class='break-word'><span><%= md(property.description, true) %></span></td>
-  <% if(property.properties && property.properties.length) { %>
-    <% property.properties.forEach(function(childProperty) { %>
-        <%= renderParamProperty({
-            property: childProperty,
-            renderParamProperty: renderParamProperty
-        }) %>
-    <% }) %>
-  <% } %>
 </tr>
+<% if(property.properties && property.properties.length) { %>
+  <% property.properties.forEach(function(childProperty) { %>
+    <%= renderParamProperty({
+      property: childProperty,
+      renderParamProperty: renderParamProperty
+    }) %>
+  <% }) %>
+<% } %>

--- a/src/default_theme/paramProperty._
+++ b/src/default_theme/paramProperty._
@@ -1,0 +1,15 @@
+<tr>
+  <td class='break-word'><span class='code bold'><%- property.name %></span> <code class='quiet'><%= formatType(property.type) %></code>
+  <% if (property.default) { %>
+    (default <code><%- property.default %></code>)
+  <% } %></td>
+  <td class='break-word'><span><%= md(property.description, true) %></span></td>
+  <% if(property.properties && property.properties.length) { %>
+    <% property.properties.forEach(function(childProperty) { %>
+        <%= renderParamProperty({
+            property: childProperty,
+            renderParamProperty: renderParamProperty
+        }) %>
+    <% }) %>
+  <% } %>
+</tr>

--- a/src/default_theme/section._
+++ b/src/default_theme/section._
@@ -66,8 +66,9 @@
             </thead>
             <tbody class='mt1'>
               <% param.properties.forEach(function(property) { %>
-                <%- renderParamProperty({
-                  property: property
+                <%= renderParamProperty({
+                  property: property,
+                  renderParamProperty: renderParamProperty
                 }) %>
               <% }) %>
             </tbody>

--- a/src/default_theme/section._
+++ b/src/default_theme/section._
@@ -66,13 +66,9 @@
             </thead>
             <tbody class='mt1'>
               <% param.properties.forEach(function(property) { %>
-                <tr>
-                  <td class='break-word'><span class='code bold'><%- property.name %></span> <code class='quiet'><%= formatType(property.type) %></code>
-                  <% if (property.default) { %>
-                    (default <code><%- property.default %></code>)
-                  <% } %></td>
-                  <td class='break-word'><span><%= md(property.description, true) %></span></td>
-                </tr>
+                <%- renderParamProperty({
+                  property: property
+                }) %>
               <% }) %>
             </tbody>
           </table>
@@ -137,16 +133,16 @@
 
   <% if (section.members.static && section.members.static.length) { %>
     <div class='py1 quiet mt1 prose-big'>Static Members</div>
-    <%= renderSectionList({ members: section.members.static, renderSection: renderSection, noun: 'Static Member' }) %>
+    <%= renderSectionList({ members: section.members.static, renderSection: renderSection, renderParamProperty: renderParamProperty, noun: 'Static Member' }) %>
   <% } %>
 
   <% if (section.members.instance && section.members.instance.length) { %>
     <div class='py1 quiet mt1 prose-big'>Instance Members</div>
-    <%= renderSectionList({ members: section.members.instance, renderSection: renderSection, noun: 'Instance Member' }) %>
+    <%= renderSectionList({ members: section.members.instance, renderSection: renderSection, renderParamProperty: renderParamProperty, noun: 'Instance Member' }) %>
   <% } %>
 
   <% if (section.members.events && section.members.events.length) { %>
     <div class='py1 quiet mt1 prose-big'>Events</div>
-    <%= renderSectionList({ members: section.members.events, renderSection: renderSection, noun: 'Event' }) %>
+    <%= renderSectionList({ members: section.members.events, renderSection: renderSection, renderParamProperty: renderParamProperty, noun: 'Event' }) %>
   <% } %>
 </section>

--- a/src/default_theme/section_list._
+++ b/src/default_theme/section_list._
@@ -11,7 +11,8 @@
         <%= renderSection({
           section: member,
           renderSection: renderSection,
-	  nested: true
+          renderParamProperty: renderParamProperty,
+     	  nested: true
         }) %>
       </div>
     </div>


### PR DESCRIPTION
Hello,

I ran into an issue where certain portions of the JSON output was not being included in the HTML output. Specifically, properties underneath parameter properties (`section.params.properties.properties`). These sub-properties are included in the MD output, so I assumed they should be part of the HTML output. So here's my fix.

#### JSDoc
```
// testFile.js
/**
 * Documentation for some function.
 * @name testFunction
 * @param {Object} options An options parameter.
 * @param  {Object} options.firstLevelOne A property of the options parameter.
 * @param  {Boolean} options.firstLevelOne.secondLevelOne A second level property.
 * @param  {Boolean} options.firstLevelOne.secondLevelTwo A second second level property.
 * @param  {Boolean} options.firstLevelTwo A second first level property.
 */
export function testFunction(options) {
    return options;
}
```

#### Expected HTML Output
![paramproperty - expected html](https://user-images.githubusercontent.com/1817346/31181130-877d9a80-a8ee-11e7-840f-b35907c0371e.png)

#### Actual HTML Output
As above, but both of the `secondLevel...` property rows are omitted.


The sub-properties were being omitted because `section._` only iterates over `param.properties` and doesn't check for anything underneath it ([here](https://github.com/documentationjs/documentation/compare/master...MichelSimonot:master#diff-dd6e1ce1151391ea58f9edc98becc8f3L68)). So I created a new template (`paramProperty._`) (to replace that portion of `section._`) that recursively checks for properties and renders them ([here](https://github.com/documentationjs/documentation/compare/master...MichelSimonot:master#diff-c1b8c9292ee9287b14c454542625f9beR8)). With this, the actual HTML output matches [my] expected HTML output.


I updated the test case input (`html/nested.input.js`) to include a case for this, but haven't updated the snapshots to reflect the new output. Wasn't sure what your process is for this.