### PR TITLE
Add --shallow and --sort-order to options for readme command

### DIFF
--- a/src/commands/readme.js
+++ b/src/commands/readme.js
@@ -1,12 +1,13 @@
 /* @flow */
 
-var fs = require('fs');
-var remark = require('remark');
-var path = require('path');
-var documentation = require('../');
-var inject = require('mdast-util-inject');
-var chalk = require('chalk');
-var disparity = require('disparity');
+var path = require('path'),
+  fs = require('fs'),
+  remark = require('remark'),
+  inject = require('mdast-util-inject'),
+  chalk = require('chalk'),
+  disparity = require('disparity'),
+  documentation = require('../'),
+  _ = require('lodash');
 
 module.exports.command = 'readme [input..]';
 module.exports.description = 'inject documentation into your README.md';
@@ -16,34 +17,53 @@ module.exports.description = 'inject documentation into your README.md';
  * @returns {Object} yargs with options
  * @private
  */
-module.exports.builder = {
-  usage:
-    'Usage: documentation readme [--readme-file=README.md] --section "API"' +
-    ' [--compare-only] [other documentationjs options]',
-  example: 'documentation readme index.js -s "API Docs" --github',
-  'readme-file': {
-    describe: 'The markdown file into which to inject documentation',
-    default: 'README.md'
-  },
-  section: {
-    alias: 's',
-    describe:
-      'The section heading after which to inject generated documentation',
-    required: true
-  },
-  'diff-only': {
-    alias: 'd',
-    describe:
-      'Instead of updating the given README with the generated documentation,' +
-      ' just check if its contents match, exiting nonzero if not.',
-    default: false
-  },
-  quiet: {
-    alias: 'q',
-    describe: 'Quiet mode: do not print messages or README diff to stdout.',
-    default: false
+module.exports.builder = _.assign(
+  {},
+  {
+    usage:
+      'Usage: documentation readme [--readme-file=README.md] --section "API"' +
+      ' [--compare-only] [other documentationjs options]',
+    example: 'documentation readme index.js -s "API Docs" --github',
+    'readme-file': {
+      describe: 'The markdown file into which to inject documentation',
+      default: 'README.md',
+      type: 'string'
+    },
+    section: {
+      alias: 's',
+      describe:
+        'The section heading after which to inject generated documentation',
+      required: true,
+      type: 'string'
+    },
+    'diff-only': {
+      alias: 'd',
+      describe:
+        'Instead of updating the given README with the generated documentation,' +
+        ' just check if its contents match, exiting nonzero if not.',
+      default: false,
+      type: 'boolean'
+    },
+    quiet: {
+      alias: 'q',
+      describe: 'Quiet mode: do not print messages or README diff to stdout.',
+      default: false,
+      type: 'boolean'
+    },
+    shallow: {
+      describe:
+        'shallow mode turns off dependency resolution, ' +
+        'only processing the specified files (or the main script specified in package.json)',
+      default: false,
+      type: 'boolean'
+    },
+    'sort-order': {
+      describe: 'The order to sort the documentation',
+      choices: ['source', 'alpha'],
+      default: 'source'
+    }
   }
-};
+);
 
 /**
  * Insert API documentation into a Markdown readme


### PR DESCRIPTION
Did some minor extra editing to make code look the same as in the build command, too.
Not all tests seem to pass on my machine, I honestly have no clue why. The command does work when you use it from the command prompt.