### PR TITLE
fix(globals-docs): Remove en-US from MDN links.

### DIFF
--- a/__tests__/__snapshots__/bin-readme.js.snap
+++ b/__tests__/__snapshots__/bin-readme.js.snap
@@ -20,7 +20,7 @@ A function with documentation.
 
 -   \`a\`  {string} blah
 
-Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** answer
+Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** answer
 
 ## bar
 
@@ -54,7 +54,7 @@ A function with documentation.
 
 -   \`a\`  {string} blah
 
-Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** answer
+Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** answer
 
 ## bar
 

--- a/__tests__/__snapshots__/bin.js.snap
+++ b/__tests__/__snapshots__/bin.js.snap
@@ -5,7 +5,7 @@ exports[`--config 1`] = `
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>documentation 5.3.3 | Documentation</title>
+  <title>documentation 5.3.4 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -17,7 +17,7 @@ exports[`--config 1`] = `
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>documentation</h3>
-          <div class='mb1'><code>5.3.3</code></div>
+          <div class='mb1'><code>5.3.4</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -334,7 +334,7 @@ This is a [klasssic]<a href=\\"#klass\\">Klass</a>
 This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</a></p>
 
 
-  <div class='pre p1 fill-light mt0'>isClass(other: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, also: any): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isClass(other: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, also: any): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
   
   
 
@@ -351,7 +351,7 @@ This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>other</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+            <span class='code bold'>other</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
 	    
           </div>
           
@@ -373,7 +373,7 @@ This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
         whether the other thing is a Klass
 
       
@@ -410,7 +410,7 @@ This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</
 the referenced class type</p>
 
 
-  <div class='pre p1 fill-light mt0'>isWeird(other: Weird): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isWeird(other: Weird): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
   
   
 
@@ -441,7 +441,7 @@ the referenced class type</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
         whether the other thing is a Klass
 
       
@@ -477,7 +477,7 @@ the referenced class type</p>
   <p>This method takes a Buffer object that will be linked to nodejs.org</p>
 
 
-  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>), size: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>), size: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
   
   
 
@@ -494,7 +494,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>buf</span> <code class='quiet'>((<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>))</code>
+            <span class='code bold'>buf</span> <code class='quiet'>((<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>))</code>
 	    
           </div>
           
@@ -502,7 +502,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>size</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>
+            <span class='code bold'>size</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>
             = <code>0</code>)</code>
 	    size
 
@@ -518,7 +518,7 @@ the referenced class type</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
         whether the other thing is a Klass
 
       
@@ -554,7 +554,7 @@ the referenced class type</p>
   <p>This method takes an array of buffers and counts them</p>
 
 
-  <div class='pre p1 fill-light mt0'>isArrayOfBuffers(buffers: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></div>
+  <div class='pre p1 fill-light mt0'>isArrayOfBuffers(buffers: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></div>
   
   
 
@@ -571,7 +571,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>buffers</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>)</code>
+            <span class='code bold'>buffers</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>)</code>
 	    some buffers
 
           </div>
@@ -586,7 +586,7 @@ the referenced class type</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>:
         how many
 
       
@@ -683,7 +683,7 @@ k.isArrayOfBuffers();</pre>
   <p>Get this Klass's foo</p>
 
 
-  <div class='pre p1 fill-light mt0'>getFoo(): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></div>
+  <div class='pre p1 fill-light mt0'>getFoo(): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></div>
   
   
 
@@ -701,7 +701,7 @@ k.isArrayOfBuffers();</pre>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></code>:
         foo
 
       
@@ -744,7 +744,7 @@ k.isArrayOfBuffers();</pre>
   <p>A function with an options parameter</p>
 
 
-  <div class='pre p1 fill-light mt0'>withOptions(options: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, otherOptions: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</div>
+  <div class='pre p1 fill-light mt0'>withOptions(options: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, otherOptions: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</div>
   
   
 
@@ -761,7 +761,7 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
 	    
           </div>
           
@@ -779,7 +779,7 @@ k.isArrayOfBuffers();</pre>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -787,7 +787,7 @@ k.isArrayOfBuffers();</pre>
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -801,7 +801,7 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</code>
+            <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</code>
 	    
           </div>
           
@@ -843,7 +843,7 @@ k.isArrayOfBuffers();</pre>
   <p>A function with a deep options parameter</p>
 
 
-  <div class='pre p1 fill-light mt0'>withDeepOptions(options: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</div>
+  <div class='pre p1 fill-light mt0'>withDeepOptions(options: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</div>
   
   
 
@@ -860,7 +860,7 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
 	    
           </div>
           
@@ -878,7 +878,7 @@ k.isArrayOfBuffers();</pre>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -886,14 +886,14 @@ k.isArrayOfBuffers();</pre>
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a></code>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
 
   
     <tr>
-  <td class='break-word'><span class='code bold'>options.bar.buz</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  <td class='break-word'><span class='code bold'>options.bar.buz</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -1025,18 +1025,18 @@ k.isArrayOfBuffers();</pre>
     <div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>error</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">object</a>)</code>
+          <span class='code bold'>error</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">object</a>)</code>
           : An error
 
           
             <ul>
               
-                <li><code>error.code</code> <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
+                <li><code>error.code</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
                   
                   <p>The error's code</p>
 </li>
               
-                <li><code>error.description</code> <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
+                <li><code>error.description</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
                   
                   <p>The error's description</p>
 </li>
@@ -1137,7 +1137,7 @@ like a <a href=\\"#klass\\">klass</a></p>
   <p>Rest property function</p>
 
 
-  <div class='pre p1 fill-light mt0'>bar(toys: ...<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
+  <div class='pre p1 fill-light mt0'>bar(toys: ...<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
   
   
 
@@ -1154,7 +1154,7 @@ like a <a href=\\"#klass\\">klass</a></p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>toys</span> <code class='quiet'>(...<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>)</code>
+            <span class='code bold'>toys</span> <code class='quiet'>(...<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>)</code>
 	    
           </div>
           
@@ -1168,7 +1168,7 @@ like a <a href=\\"#klass\\">klass</a></p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
         nothing
 
       
@@ -1204,10 +1204,10 @@ like a <a href=\\"#klass\\">klass</a></p>
 
   <p>Get an instance of <a href=\\"#klass\\">Klass</a>. Will make
 a <a href=\\"#klass\\">klass instance multiword</a>,
-like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a> input.</p>
+like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a> input.</p>
 
 
-  <div class='pre p1 fill-light mt0'>bar(): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
+  <div class='pre p1 fill-light mt0'>bar(): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
   
   
 
@@ -1225,7 +1225,7 @@ like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
         nothing
 
       
@@ -1814,7 +1814,7 @@ exports[`build --document-exported 1`] = `
 
 **Parameters**
 
--   \`a\` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   \`a\` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 ### classMethod
 
@@ -1838,7 +1838,7 @@ exports[`build --document-exported 1`] = `
 
 ## T5
 
-Type: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
+Type: [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
 
 ## y2Default
 
@@ -1848,7 +1848,7 @@ Description of y3
 
 **Parameters**
 
--   \`p\` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   \`p\` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
 
@@ -1874,15 +1874,15 @@ Returns **void**
 
 ## T
 
-Type: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+Type: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)
 
 ## T2
 
-Type: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
+Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 ## T4
 
-Type: [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
+Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)
 
 ## f4
 

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -9,7 +9,7 @@ This is my class, a demo thing.
 
 **Properties**
 
--   \`howMany\` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** how many things it contains
+-   \`howMany\` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** how many things it contains
 
 ### getFoo
 
@@ -17,15 +17,15 @@ Get the number 42
 
 **Parameters**
 
--   \`getIt\` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether to get the number
+-   \`getIt\` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether to get the number
 
-Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** forty-two
+Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** forty-two
 
 ### getUndefined
 
 Get undefined
 
-Returns **[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)** does not return anything.
+Returns **[undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined)** does not return anything.
 
 ## Hello
 
@@ -766,7 +766,7 @@ exports[`git option 2`] = `
 
 This function returns the number one.
 
-Returns **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** numberone
+Returns **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** numberone
 "
 `;
 
@@ -796,10 +796,10 @@ myFoo.foo(42);
 }
 \`\`\`
 
--   Throws **[Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)** if you give it something
--   Throws **[TypeError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError)** if you give it something else
+-   Throws **[Error](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error)** if you give it something
+-   Throws **[TypeError](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError)** if you give it something else
 
-Returns **[Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** numberone
+Returns **[Number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** numberone
 "
 `;
 
@@ -808,7 +808,7 @@ exports[`html nested.input.js 1`] = `
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>documentation 5.3.3 | Documentation</title>
+  <title>documentation 5.3.4 | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -820,7 +820,7 @@ exports[`html nested.input.js 1`] = `
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>documentation</h3>
-          <div class='mb1'><code>5.3.3</code></div>
+          <div class='mb1'><code>5.3.4</code></div>
           <input
             placeholder='Filter'
             id='filter-input'
@@ -1099,7 +1099,7 @@ This is a [klasssic]<a href=\\"#klass\\">Klass</a>
 This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</a></p>
 
 
-  <div class='pre p1 fill-light mt0'>isClass(other: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, also: any): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isClass(other: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, also: any): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
   
   
 
@@ -1116,7 +1116,7 @@ This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>other</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+            <span class='code bold'>other</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
 	    
           </div>
           
@@ -1138,7 +1138,7 @@ This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
         whether the other thing is a Klass
 
       
@@ -1175,7 +1175,7 @@ This is a [link to something that does not exist]<a href=\\"DoesNot\\">DoesNot</
 the referenced class type</p>
 
 
-  <div class='pre p1 fill-light mt0'>isWeird(other: Weird): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isWeird(other: Weird): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
   
   
 
@@ -1206,7 +1206,7 @@ the referenced class type</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
         whether the other thing is a Klass
 
       
@@ -1242,7 +1242,7 @@ the referenced class type</p>
   <p>This method takes a Buffer object that will be linked to nodejs.org</p>
 
 
-  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>), size: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
+  <div class='pre p1 fill-light mt0'>isBuffer(buf: (<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>), size: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></div>
   
   
 
@@ -1259,7 +1259,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>buf</span> <code class='quiet'>((<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>))</code>
+            <span class='code bold'>buf</span> <code class='quiet'>((<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a> | <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>))</code>
 	    
           </div>
           
@@ -1267,7 +1267,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>size</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>
+            <span class='code bold'>size</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>
             = <code>0</code>)</code>
 	    size
 
@@ -1283,7 +1283,7 @@ the referenced class type</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean\\">boolean</a></code>:
         whether the other thing is a Klass
 
       
@@ -1319,7 +1319,7 @@ the referenced class type</p>
   <p>This method takes an array of buffers and counts them</p>
 
 
-  <div class='pre p1 fill-light mt0'>isArrayOfBuffers(buffers: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></div>
+  <div class='pre p1 fill-light mt0'>isArrayOfBuffers(buffers: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></div>
   
   
 
@@ -1336,7 +1336,7 @@ the referenced class type</p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>buffers</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>)</code>
+            <span class='code bold'>buffers</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array\\">Array</a>&#x3C;<a href=\\"https://nodejs.org/api/buffer.html\\">Buffer</a>>)</code>
 	    some buffers
 
           </div>
@@ -1351,7 +1351,7 @@ the referenced class type</p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>:
         how many
 
       
@@ -1448,7 +1448,7 @@ k.isArrayOfBuffers();</pre>
   <p>Get this Klass's foo</p>
 
 
-  <div class='pre p1 fill-light mt0'>getFoo(): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></div>
+  <div class='pre p1 fill-light mt0'>getFoo(): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></div>
   
   
 
@@ -1466,7 +1466,7 @@ k.isArrayOfBuffers();</pre>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a></code>:
         foo
 
       
@@ -1509,7 +1509,7 @@ k.isArrayOfBuffers();</pre>
   <p>A function with an options parameter</p>
 
 
-  <div class='pre p1 fill-light mt0'>withOptions(options: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, otherOptions: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</div>
+  <div class='pre p1 fill-light mt0'>withOptions(options: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>, otherOptions: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</div>
   
   
 
@@ -1526,7 +1526,7 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
 	    
           </div>
           
@@ -1544,7 +1544,7 @@ k.isArrayOfBuffers();</pre>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -1552,7 +1552,7 @@ k.isArrayOfBuffers();</pre>
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -1566,7 +1566,7 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</code>
+            <span class='code bold'>otherOptions</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a>?)</code>
 	    
           </div>
           
@@ -1608,7 +1608,7 @@ k.isArrayOfBuffers();</pre>
   <p>A function with a deep options parameter</p>
 
 
-  <div class='pre p1 fill-light mt0'>withDeepOptions(options: <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</div>
+  <div class='pre p1 fill-light mt0'>withDeepOptions(options: <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</div>
   
   
 
@@ -1625,7 +1625,7 @@ k.isArrayOfBuffers();</pre>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
+            <span class='code bold'>options</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a>)</code>
 	    
           </div>
           
@@ -1643,7 +1643,7 @@ k.isArrayOfBuffers();</pre>
             <tbody class='mt1'>
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  <td class='break-word'><span class='code bold'>options.foo</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -1651,14 +1651,14 @@ k.isArrayOfBuffers();</pre>
 
               
                 <tr>
-  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a></code>
+  <td class='break-word'><span class='code bold'>options.bar</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">Object</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
 
   
     <tr>
-  <td class='break-word'><span class='code bold'>options.bar.buz</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
+  <td class='break-word'><span class='code bold'>options.bar.buz</span> <code class='quiet'><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a></code>
   </td>
   <td class='break-word'><span></span></td>
 </tr>
@@ -1790,18 +1790,18 @@ k.isArrayOfBuffers();</pre>
     <div>
       
         <div class='space-bottom0'>
-          <span class='code bold'>error</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object\\">object</a>)</code>
+          <span class='code bold'>error</span> <code class='quiet'>(<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object\\">object</a>)</code>
           : An error
 
           
             <ul>
               
-                <li><code>error.code</code> <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
+                <li><code>error.code</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
                   
                   <p>The error's code</p>
 </li>
               
-                <li><code>error.description</code> <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
+                <li><code>error.description</code> <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String\\">string</a>
                   
                   <p>The error's description</p>
 </li>
@@ -1902,7 +1902,7 @@ like a <a href=\\"#klass\\">klass</a></p>
   <p>Rest property function</p>
 
 
-  <div class='pre p1 fill-light mt0'>bar(toys: ...<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
+  <div class='pre p1 fill-light mt0'>bar(toys: ...<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
   
   
 
@@ -1919,7 +1919,7 @@ like a <a href=\\"#klass\\">klass</a></p>
       
         <div class='space-bottom0'>
           <div>
-            <span class='code bold'>toys</span> <code class='quiet'>(...<a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>)</code>
+            <span class='code bold'>toys</span> <code class='quiet'>(...<a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">Number</a>)</code>
 	    
           </div>
           
@@ -1933,7 +1933,7 @@ like a <a href=\\"#klass\\">klass</a></p>
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
         nothing
 
       
@@ -1969,10 +1969,10 @@ like a <a href=\\"#klass\\">klass</a></p>
 
   <p>Get an instance of <a href=\\"#klass\\">Klass</a>. Will make
 a <a href=\\"#klass\\">klass instance multiword</a>,
-like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a> input.</p>
+like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number\\">number</a> input.</p>
 
 
-  <div class='pre p1 fill-light mt0'>bar(): <a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
+  <div class='pre p1 fill-light mt0'>bar(): <a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></div>
   
   
 
@@ -1990,7 +1990,7 @@ like a <a href=\\"#klass\\">klass</a>. This needs a <a href=\\"https://developer
   
     
       <div class='py1 quiet mt1 prose-big'>Returns</div>
-      <code><a href=\\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
+      <code><a href=\\"https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined\\">undefined</a></code>:
         nothing
 
       
@@ -3583,9 +3583,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -3716,9 +3716,9 @@ Object {
                           "value": "boolean",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                     },
                   ],
                   "type": "strong",
@@ -3787,9 +3787,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -3896,9 +3896,9 @@ Object {
                   "value": "undefined",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
             },
           ],
           "type": "strong",
@@ -6200,9 +6200,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -6378,9 +6378,9 @@ Object {
               "value": "boolean",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
         },
       ],
       "type": "paragraph",
@@ -6472,9 +6472,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -6655,9 +6655,9 @@ Object {
               "value": "number",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
         },
       ],
       "type": "paragraph",
@@ -6685,9 +6685,9 @@ Object {
               "value": "string",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
         },
       ],
       "type": "paragraph",
@@ -6715,9 +6715,9 @@ Object {
               "value": "string",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
         },
       ],
       "type": "paragraph",
@@ -10126,9 +10126,9 @@ have any parameter descriptions.",
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                   ],
                   "type": "strong",
@@ -10360,9 +10360,9 @@ have any parameter descriptions.",
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                   ],
                   "type": "strong",
@@ -10544,9 +10544,9 @@ have any parameter descriptions.",
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                     Object {
                       "type": "text",
@@ -10559,9 +10559,9 @@ have any parameter descriptions.",
                           "value": "Number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                     Object {
                       "type": "text",
@@ -10656,9 +10656,9 @@ have any parameter descriptions.",
                   "value": "Number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -10782,9 +10782,9 @@ have any parameter descriptions.",
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -10855,9 +10855,9 @@ have any parameter descriptions.",
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -11295,7 +11295,7 @@ It takes a ",
           },
           "title": null,
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
         },
         Object {
           "position": Position {
@@ -11572,9 +11572,9 @@ It takes a ",
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -11698,9 +11698,9 @@ It takes a ",
                   "value": "Number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -12058,9 +12058,9 @@ It takes a ",
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                     Object {
                       "type": "text",
@@ -12108,9 +12108,9 @@ It takes a ",
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                     Object {
                       "type": "text",
@@ -12190,9 +12190,9 @@ It takes a ",
                           "value": "boolean",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                     },
                   ],
                   "type": "strong",
@@ -12243,9 +12243,9 @@ It takes a ",
                   "value": "boolean",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
             },
           ],
           "type": "strong",
@@ -12363,9 +12363,9 @@ It takes a ",
                   "value": "boolean",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
             },
           ],
           "type": "strong",
@@ -13016,9 +13016,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -13159,9 +13159,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -13197,9 +13197,9 @@ Object {
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                     Object {
                       "type": "text",
@@ -13212,9 +13212,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                     Object {
                       "type": "text",
@@ -13933,9 +13933,9 @@ Object {
                   "value": "Number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -14087,9 +14087,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -14558,9 +14558,9 @@ Object {
                           "value": "Event",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/API/Event",
+                      "href": "https://developer.mozilla.org/docs/Web/API/Event",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/API/Event",
+                      "url": "https://developer.mozilla.org/docs/Web/API/Event",
                     },
                   ],
                   "type": "strong",
@@ -14998,9 +14998,9 @@ Object {
                   "value": "Number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -16350,9 +16350,9 @@ Object {
               "value": "string",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
         },
       ],
       "type": "paragraph",
@@ -16419,9 +16419,9 @@ Object {
               "value": "Array",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
         },
         Object {
           "type": "text",
@@ -16434,9 +16434,9 @@ Object {
               "value": "string",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
         },
         Object {
           "type": "text",
@@ -16465,9 +16465,9 @@ Object {
               "value": "number",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
         },
         Object {
           "type": "text",
@@ -16542,9 +16542,9 @@ Object {
               "value": "Array",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
         },
         Object {
           "type": "text",
@@ -16557,9 +16557,9 @@ Object {
               "value": "string",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
         },
         Object {
           "type": "text",
@@ -16588,9 +16588,9 @@ Object {
               "value": "number",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
         },
         Object {
           "type": "text",
@@ -17944,9 +17944,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -18015,9 +18015,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -18323,9 +18323,9 @@ and ",
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -18394,9 +18394,9 @@ and ",
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -18687,9 +18687,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -18725,9 +18725,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -19767,9 +19767,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -19838,9 +19838,9 @@ Object {
                   "value": "string",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
             },
           ],
           "type": "strong",
@@ -19964,9 +19964,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -20035,9 +20035,9 @@ Object {
                   "value": "string",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
             },
           ],
           "type": "strong",
@@ -21211,9 +21211,9 @@ Object {
                           "value": "boolean",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
                     },
                   ],
                   "type": "strong",
@@ -21282,9 +21282,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -21391,9 +21391,9 @@ Object {
                   "value": "undefined",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
             },
           ],
           "type": "strong",
@@ -21842,9 +21842,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -21913,9 +21913,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -22674,9 +22674,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -23430,9 +23430,9 @@ Object {
                   "value": "Date",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
             },
           ],
           "type": "strong",
@@ -23556,9 +23556,9 @@ Object {
                           "value": "Date",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
                     },
                   ],
                   "type": "strong",
@@ -23627,9 +23627,9 @@ Object {
                   "value": "undefined",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
             },
           ],
           "type": "strong",
@@ -24299,9 +24299,9 @@ Object {
                           "value": "object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                   ],
                   "type": "strong",
@@ -24336,9 +24336,9 @@ Object {
                                   "value": "string",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                             },
                           ],
                           "type": "strong",
@@ -24477,9 +24477,9 @@ Object {
                                   "value": "string",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                             },
                           ],
                           "type": "strong",
@@ -24557,9 +24557,9 @@ Object {
                           "value": "function",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
                     },
                     Object {
                       "type": "text",
@@ -24666,9 +24666,9 @@ Object {
                   "value": "Promise",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
             },
           ],
           "type": "strong",
@@ -25610,9 +25610,9 @@ Object {
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                     Object {
                       "type": "text",
@@ -25625,9 +25625,9 @@ Object {
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                     Object {
                       "type": "text",
@@ -25701,9 +25701,9 @@ Object {
                                   "value": "string",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                             },
                           ],
                           "type": "strong",
@@ -25774,9 +25774,9 @@ Object {
                                   "value": "string",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                             },
                           ],
                           "type": "strong",
@@ -25854,9 +25854,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -25969,9 +25969,9 @@ Object {
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                   ],
                   "type": "strong",
@@ -26041,9 +26041,9 @@ Object {
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                           ],
                           "type": "strong",
@@ -26121,9 +26121,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -26209,9 +26209,9 @@ Object {
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                   ],
                   "type": "strong",
@@ -26281,9 +26281,9 @@ Object {
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                           ],
                           "type": "strong",
@@ -26319,9 +26319,9 @@ Object {
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                           ],
                           "type": "strong",
@@ -26357,9 +26357,9 @@ Object {
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                           ],
                           "type": "strong",
@@ -26400,9 +26400,9 @@ Object {
                   "value": "Object",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
             },
           ],
           "type": "strong",
@@ -26727,9 +26727,9 @@ Object {
                           "value": "Number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -27007,9 +27007,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -27175,9 +27175,9 @@ Object {
               "value": "number",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
         },
         Object {
           "type": "text",
@@ -27198,9 +27198,9 @@ Object {
               "value": "string",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
         },
         Object {
           "type": "text",
@@ -27241,9 +27241,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                     Object {
                       "type": "text",
@@ -27283,9 +27283,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -30253,9 +30253,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -30348,9 +30348,9 @@ Object {
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                   ],
                   "type": "strong",
@@ -30518,9 +30518,9 @@ Object {
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                   ],
                   "type": "strong",
@@ -30555,9 +30555,9 @@ Object {
                                   "value": "String",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                             },
                           ],
                           "type": "strong",
@@ -30717,9 +30717,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -30877,9 +30877,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -31172,9 +31172,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                   ],
                   "type": "strong",
@@ -31245,9 +31245,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -31335,9 +31335,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                     Object {
                       "type": "text",
@@ -31412,9 +31412,9 @@ Object {
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                   ],
                   "type": "strong",
@@ -31611,9 +31611,9 @@ Object {
                           "value": "Object",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                     },
                     Object {
                       "type": "text",
@@ -31691,9 +31691,9 @@ Object {
                                   "value": "Object",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
                             },
                             Object {
                               "type": "text",
@@ -31706,9 +31706,9 @@ Object {
                                   "value": "string",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                             },
                             Object {
                               "type": "text",
@@ -31788,9 +31788,9 @@ The latter is preferable in case of large GeoJSON files.",
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                           ],
                           "type": "strong",
@@ -31878,9 +31878,9 @@ The latter is preferable in case of large GeoJSON files.",
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                             Object {
                               "type": "text",
@@ -31955,9 +31955,9 @@ The latter is preferable in case of large GeoJSON files.",
                                   "value": "number",
                                 },
                               ],
-                              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                               "type": "link",
-                              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                             },
                             Object {
                               "type": "text",
@@ -32104,9 +32104,9 @@ values specified in code.",
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -32192,9 +32192,9 @@ values specified in code.",
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -32445,9 +32445,9 @@ iterator destructure (RestElement)",
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                   ],
                   "type": "strong",
@@ -32623,9 +32623,9 @@ iterator destructure (RestElement)",
                   "value": "Array",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
             },
             Object {
               "type": "text",
@@ -34395,9 +34395,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -35059,9 +35059,9 @@ plus 3.",
                           "value": "Number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -35246,9 +35246,9 @@ plus 3.",
               "value": "Function",
             },
           ],
-          "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function",
+          "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
           "type": "link",
-          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function",
+          "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
         },
       ],
       "type": "paragraph",
@@ -35285,9 +35285,9 @@ plus 3.",
                           "value": "Error",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error",
                     },
                     Object {
                       "type": "text",
@@ -35362,9 +35362,9 @@ plus 3.",
                           "value": "Number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -35669,9 +35669,9 @@ Object {
                   "value": "Number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -36117,9 +36117,9 @@ Object {
                           "value": "Number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -36203,9 +36203,9 @@ Object {
                   "value": "Number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -37553,9 +37553,9 @@ Object {
                   "value": "number",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
             },
           ],
           "type": "strong",
@@ -38514,9 +38514,9 @@ Object {
                           "value": "Array",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
                     },
                     Object {
                       "type": "text",
@@ -38529,9 +38529,9 @@ Object {
                           "value": "string",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
                     },
                     Object {
                       "type": "text",
@@ -38719,9 +38719,9 @@ Object {
                           "value": "number",
                         },
                       ],
-                      "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                       "type": "link",
-                      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number",
+                      "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
                     },
                   ],
                   "type": "strong",
@@ -38755,9 +38755,9 @@ Object {
                   "value": "boolean",
                 },
               ],
-              "href": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "href": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
               "type": "link",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
+              "url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
             },
           ],
           "type": "strong",

--- a/__tests__/format_type.js
+++ b/__tests__/format_type.js
@@ -23,47 +23,47 @@ test('formatType', function() {
     ['namedType.typeProperty', 'namedType.typeProperty'],
     [
       'Array|undefined',
-      '([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) \\| [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined))'
+      '([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array) \\| [undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined))'
     ],
     [
       'Array<number>',
-      '[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>'
+      '[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>'
     ],
     [
       'number!',
-      '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)!'
+      '[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)!'
     ],
     ["('pre'|'post')", '(`"pre"` \\| `"post"`)'],
     ["'pre'|'post'", '(`"pre"` \\| `"post"`)'],
     [
       'function(string, boolean)',
-      'function ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean))'
+      'function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean))'
     ],
     [
       'function(string, boolean): number',
-      'function ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)): [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'
+      'function ([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String), [boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)): [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)'
     ],
     ['function()', 'function ()'],
     [
       'function(this:something, string)',
-      'function (this: something, [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))'
+      'function (this: something, [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))'
     ],
     ['function(new:something)', 'function (new: something)'],
     [
       '{myNum: number, myObject}',
-      '{myNum: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), myObject}'
+      '{myNum: [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number), myObject}'
     ],
     [
       '[string,]',
-      '\\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]'
+      '\\[[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)]'
     ],
     [
       'number?',
-      '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?'
+      '[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?'
     ],
     [
       'number',
-      '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'
+      '[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)'
     ],
     ['?', '?'],
     ['void', 'void'],
@@ -71,15 +71,15 @@ test('formatType', function() {
     ['function(a):void', 'function (a): void'],
     [
       'number=',
-      '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?'
+      '[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?'
     ],
     [
       '...number',
-      '...[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'
+      '...[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)'
     ],
     [
       'undefined',
-      '[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)'
+      '[undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined)'
     ]
   ].forEach(function(example) {
     expect(
@@ -96,7 +96,7 @@ test('formatType', function() {
       formatType(parse('@param {number} [a=1]', { sloppy: true }).tags[0].type)
     )
   ).toEqual(
-    '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?'
+    '[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)?'
   );
 
   expect(

--- a/__tests__/linker.js
+++ b/__tests__/linker.js
@@ -4,7 +4,7 @@ test('linkerStack', function() {
   var linkerStack = new LinkerStack({});
 
   expect(linkerStack.link('string')).toBe(
-    'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String'
+    'https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String'
   );
 
   expect(

--- a/docs/NODE_API.md
+++ b/docs/NODE_API.md
@@ -17,18 +17,18 @@ of lint information intended for human-readable output.
 
 **Parameters**
 
--   `indexes` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** files to process
--   `args` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** args
-    -   `args.external` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** a string regex / glob match pattern
+-   `indexes` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** files to process
+-   `args` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** args
+    -   `args.external` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** a string regex / glob match pattern
         that defines what external modules will be whitelisted and included in the
         generated documentation.
-    -   `args.shallow` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether to avoid dependency parsing
+    -   `args.shallow` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether to avoid dependency parsing
         even in JavaScript code. (optional, default `false`)
-    -   `args.inferPrivate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** a valid regular expression string
+    -   `args.inferPrivate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a valid regular expression string
         to infer whether a code element should be private, given its naming structure.
         For instance, you can specify `inferPrivate: '^_'` to automatically treat
         methods named like `_myMethod` as private.
-    -   `args.extension` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>)?** treat additional file extensions
+    -   `args.extension` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)?** treat additional file extensions
         as JavaScript, extending the default set of `js`, `es6`, and `jsx`.
 
 **Examples**
@@ -44,7 +44,7 @@ documentation.lint('file.js').then(lintOutput => {
 });
 ```
 
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)** promise with lint results
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** promise with lint results
 
 ## build
 
@@ -53,25 +53,25 @@ comments, given a root file as a path.
 
 **Parameters**
 
--   `indexes` **([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))** files to process
--   `args` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** args
-    -   `args.external` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** a string regex / glob match pattern
+-   `indexes` **([Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)> | [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String))** files to process
+-   `args` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** args
+    -   `args.external` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** a string regex / glob match pattern
         that defines what external modules will be whitelisted and included in the
         generated documentation.
-    -   `args.shallow` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether to avoid dependency parsing
+    -   `args.shallow` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** whether to avoid dependency parsing
         even in JavaScript code. (optional, default `false`)
-    -   `args.order` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object))>** optional array that
+    -   `args.order` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object))>** optional array that
         defines sorting order of documentation (optional, default `[]`)
-    -   `args.access` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** an array of access levels
+    -   `args.access` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** an array of access levels
         to output in documentation (optional, default `[]`)
-    -   `args.hljs` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)?** hljs optional args
-        -   `args.hljs.highlightAuto` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** hljs automatically detect language (optional, default `false`)
-        -   `args.hljs.languages` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)?** languages for hljs to choose from
-    -   `args.inferPrivate` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** a valid regular expression string
+    -   `args.hljs` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)?** hljs optional args
+        -   `args.hljs.highlightAuto` **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** hljs automatically detect language (optional, default `false`)
+        -   `args.hljs.languages` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)?** languages for hljs to choose from
+    -   `args.inferPrivate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** a valid regular expression string
         to infer whether a code element should be private, given its naming structure.
         For instance, you can specify `inferPrivate: '^_'` to automatically treat
         methods named like `_myMethod` as private.
-    -   `args.extension` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>)?** treat additional file extensions
+    -   `args.extension` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>)?** treat additional file extensions
         as JavaScript, extending the default set of `js`, `es6`, and `jsx`.
 
 **Examples**
@@ -89,7 +89,7 @@ documentation.build(['index.js'], {
 });
 ```
 
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)** results
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)** results
 
 ## formats
 
@@ -104,9 +104,9 @@ Formats documentation as HTML.
 
 **Parameters**
 
--   `comments` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Comment](https://developer.mozilla.org/en-US/docs/Web/API/Comment/Comment)>** parsed comments
--   `config` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output
-    -   `config.theme` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of a module used for an HTML theme. (optional, default `'default_theme'`)
+-   `comments` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Comment](https://developer.mozilla.org/docs/Web/API/Comment/Comment)>** parsed comments
+-   `config` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output
+    -   `config.theme` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of a module used for an HTML theme. (optional, default `'default_theme'`)
 
 **Examples**
 
@@ -122,7 +122,7 @@ documentation.build(['index.js'])
   });
 ```
 
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>>** Promise with results
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>>** Promise with results
 
 ## formats.markdown
 
@@ -131,8 +131,8 @@ Formats documentation as
 
 **Parameters**
 
--   `comments` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)>** parsed comments
--   `args` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output
+-   `comments` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)>** parsed comments
+-   `args` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Options that can customize the output
 
 **Examples**
 
@@ -148,7 +148,7 @@ documentation.build(['index.js'])
   });
 ```
 
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** a promise of the eventual value
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** a promise of the eventual value
 
 ## formats.json
 
@@ -156,7 +156,7 @@ Formats documentation as a JSON string.
 
 **Parameters**
 
--   `comments` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Comment](https://developer.mozilla.org/en-US/docs/Web/API/Comment/Comment)>** parsed comments
+-   `comments` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Comment](https://developer.mozilla.org/docs/Web/API/Comment/Comment)>** parsed comments
 
 **Examples**
 
@@ -172,4 +172,4 @@ documentation.build(['index.js'])
   });
 ```
 
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "git-url-parse": "^6.0.1",
     "github-slugger": "1.2.0",
     "glob": "^7.0.0",
-    "globals-docs": "^2.3.0",
+    "globals-docs": "^2.4.0",
     "highlight.js": "^9.1.0",
     "js-yaml": "^3.8.4",
     "lodash": "^4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,9 +2469,9 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals-docs@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/globals-docs/-/globals-docs-2.3.0.tgz#dca4088af196f7800f4eba783eaeff335cb6759c"
+globals-docs@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/globals-docs/-/globals-docs-2.4.0.tgz#f2c647544eb6161c7c38452808e16e693c2dafbb"
 
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"


### PR DESCRIPTION
This allows the Mozilla Developer Network to infer the user language.

Fix #964