### PR TITLE
Fix .npmignore for tests folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,4 @@
 .nyc_output
 circle.yml
 coverage
-test
+__tests__


### PR DESCRIPTION
Seems like `.npmignore` was not updated after Jest was introduced and now `__tests__` are the part of the package in NPM: https://unpkg.com/documentation@5.3.5/
