### PR TITLE
Add support for class param declarations at the constructor

### DIFF
--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -52,7 +52,11 @@ function inferParams(comment: Comment) {
 
 function inferAndCombineParams(params, comment) {
   const inferredParams = params.map((param, i) => paramToDoc(param, '', i));
-  const mergedParamsAndErrors = mergeTrees(inferredParams, comment.params);
+  const paramsToMerge = comment.params;
+  if (comment.constructorComment) {
+    paramsToMerge.push.apply(paramsToMerge, comment.constructorComment.params);
+  }
+  const mergedParamsAndErrors = mergeTrees(inferredParams, paramsToMerge);
 
   // Then merge the trees. This is the hard part.
   return Object.assign(comment, {

--- a/src/parsers/javascript.js
+++ b/src/parsers/javascript.js
@@ -103,7 +103,7 @@ function _addComment(
 
       if (t.isClassMethod(path) && path.node.kind === 'constructor') {
         // #689
-        if (!comment.hideconstructor) {
+        if (comment.tags.some(tag => tag.title !== 'param' && tag.title !== 'hideconstructor')) {
           debuglog(
             'A constructor was documented explicitly: document along with the class instead'
           );


### PR DESCRIPTION
My main motivation for this was that VSCode intellisense does not work when constructor params are defined at the class declaration, it expects them at the constructor. 

So I just merged the params from a constructor comment during the infer phase. 

Relevant issue: https://github.com/documentationjs/documentation/issues/689

This was my first look into this code and I couldn't get the build to work locally let alone the tests so I'm hoping the tests can be checked in circle. 

Edit: Just to clarify, I did actually test that it did what I wanted to by editing my local node_module/documentation/lib files directly. I was getting flow type syntax errors on build and I'm not very familiar with flow so this was the easiest way for me to work with it.