### PR TITLE
Support the .mjs extension by default.

### DIFF
--- a/src/input/dependency.js
+++ b/src/input/dependency.js
@@ -32,7 +32,7 @@ function dependencyStream(
     extensions: []
       .concat(config.requireExtension || [])
       .map(ext => '.' + ext.replace(/^\./, ''))
-      .concat(['.js', '.json', '.es6', '.jsx']),
+      .concat(['.mjs', '.js', '.json', '.es6', '.jsx']),
     transform: [
       babelify.configure({
         sourceMap: false,

--- a/src/merge_config.js
+++ b/src/merge_config.js
@@ -84,6 +84,7 @@ function mergeConfigFile(config): Promise<Object> {
 
 function mergeConfig(config: Object): Promise<DocumentationConfig> {
   config.parseExtension = (config.parseExtension || []).concat([
+    'mjs',
     'js',
     'jsx',
     'es5',


### PR DESCRIPTION
Fixes https://github.com/documentationjs/documentation/issues/1022.

`.mjs` is ordered before `.js` as that is the resolution order in other tools such as Webpack v4.