### PR TITLE
Fix github links for @typedef comments

### DIFF
--- a/__tests__/lib/github.js
+++ b/__tests__/lib/github.js
@@ -104,6 +104,6 @@ test('typedef', function() {
     })[0].context.github
   ).toEqual({
     path: 'index.js',
-    url: 'https://github.com/foo/bar/blob/this_is_the_sha/index.js#L1-L4'
+    url: 'https://github.com/foo/bar/blob/this_is_the_sha/index.js#L2-L5'
   });
 });

--- a/__tests__/lib/github.js
+++ b/__tests__/lib/github.js
@@ -85,3 +85,29 @@ test('enterprise repository', function() {
 
   mock.restore();
 });
+
+test('typedef', function() {
+  mock(mockRepo.master);
+
+  expect(
+    evaluate(function() {
+      /**
+       * A number, or a string containing a number.
+       * @typedef {(number|string)} NumberLike
+       */
+
+      /**
+       * get one
+       * @returns {number} one
+       */
+      function getOne() {
+        return 1;
+      }
+    })[0].context.github
+  ).toEqual({
+    path: 'index.js',
+    url: 'https://github.com/foo/bar/blob/this_is_the_sha/index.js#L1-L4'
+  });
+
+  mock.restore();
+});

--- a/__tests__/lib/github.js
+++ b/__tests__/lib/github.js
@@ -25,6 +25,10 @@ function evaluate(fn) {
   );
 }
 
+afterEach(function() {
+  mock.restore();
+});
+
 test('github', function() {
   mock(mockRepo.master);
 
@@ -42,8 +46,6 @@ test('github', function() {
     path: 'index.js',
     url: 'https://github.com/foo/bar/blob/this_is_the_sha/index.js#L6-L8'
   });
-
-  mock.restore();
 });
 
 test('malformed repository', function() {
@@ -60,8 +62,6 @@ test('malformed repository', function() {
       }
     })[0].context.github
   ).toBe(undefined);
-
-  mock.restore();
 });
 
 test('enterprise repository', function() {
@@ -82,8 +82,6 @@ test('enterprise repository', function() {
     url:
       'https://github.enterprise.com/foo/bar/blob/this_is_the_sha/index.js#L6-L8'
   });
-
-  mock.restore();
 });
 
 test('typedef', function() {
@@ -108,6 +106,4 @@ test('typedef', function() {
     path: 'index.js',
     url: 'https://github.com/foo/bar/blob/this_is_the_sha/index.js#L1-L4'
   });
-
-  mock.restore();
 });

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -106,6 +106,7 @@ type Comment = {
   type?: DoctrineType,
 
   context: CommentContext,
+  loc: CommentLoc,
 
   path?: Array<{
     name: string,

--- a/src/github.js
+++ b/src/github.js
@@ -21,15 +21,20 @@ module.exports = function(comment: Comment) {
     .join('/');
 
   if (urlPrefix) {
+    let startLine;
+    let endLine;
+
+    if (comment.kind == 'typedef') {
+      startLine = comment.loc.start.line;
+      endLine = comment.loc.end.line;
+    } else {
+      startLine = comment.context.loc.start.line;
+      endLine = comment.context.loc.end.line;
+    }
+
     comment.context.github = {
       url:
-        urlPrefix +
-        fileRelativePath +
-        '#L' +
-        comment.context.loc.start.line +
-        '-' +
-        'L' +
-        comment.context.loc.end.line,
+        urlPrefix + fileRelativePath + '#L' + startLine + '-' + 'L' + endLine,
       path: fileRelativePath
     };
   }


### PR DESCRIPTION
Unlike other comment blocks, `@typedef` blocks are usually not directly associated with any lines of code.

eg, from [usejsdoc](http://usejsdoc.org/tags-typedef.html):

```javascript
/**
 * A number, or a string containing a number.
 * @typedef {(number|string)} NumberLike
 */

/**
 * Set the magic number.
 * @param {NumberLike} x - The magic number.
 */
function setMagicNumber(x) {
}
```

Currently, the github link that's produced for a `@typedef` block points to the nearest AST node, which would be the `function` in this case. This change uses the comment block's location instead.