### PR TITLE
fix: Make documentation.js compatible with node 4.x for one more version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.4",
     "mdast-util-inject": "^1.1.0",
     "micromatch": "^3.1.5",
-    "mime": "^2.2.0",
+    "mime": "^1.4.1",
     "module-deps-sortable": "4.0.6",
     "parse-filepath": "^1.0.2",
     "pify": "^3.0.0",

--- a/src/serve/server.js
+++ b/src/serve/server.js
@@ -75,7 +75,7 @@ class Server extends EventEmitter {
       const file = this._files[i];
       const filePath = file.relative.split(sep).join('/');
       if (filePath === path) {
-        response.writeHead(200, { 'Content-Type': mime.getType(path) });
+        response.writeHead(200, { 'Content-Type': mime.lookup(path) });
         response.end(file.contents);
         return;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4395,9 +4395,9 @@ mime-types@~2.1.17:
   dependencies:
     mime-db "~1.30.0"
 
-mime@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.0.tgz#161e541965551d3b549fa1114391e3a3d55b923b"
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
After a release containing this commit is rolled, documentation.js will
go to 6.x and will require Node > 6.x

Fixes #1014