### PR TITLE
fix: lends with object property using literal key 

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -19116,7 +19116,7 @@ Array [
       "loc": Object {
         "end": Object {
           "column": 2,
-          "line": 26,
+          "line": 28,
         },
         "start": Object {
           "column": 0,
@@ -19199,12 +19199,119 @@ Array [
           "context": Object {
             "loc": Object {
               "end": Object {
-                "column": 5,
-                "line": 16,
+                "column": 20,
+                "line": 10,
               },
               "start": Object {
                 "column": 4,
-                "line": 14,
+                "line": 10,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "end": Object {
+                        "column": 9,
+                        "line": 1,
+                        "offset": 8,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "My field",
+                  },
+                ],
+                "position": Object {
+                  "end": Object {
+                    "column": 9,
+                    "line": 1,
+                    "offset": 8,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 9,
+                "line": 1,
+                "offset": 8,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "loc": Object {
+            "end": Object {
+              "column": 19,
+              "line": 9,
+            },
+            "start": Object {
+              "column": 4,
+              "line": 9,
+            },
+          },
+          "memberof": "TheClass",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "my-field",
+          "namespace": "TheClass#my-field",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "class",
+              "name": "TheClass",
+            },
+            Object {
+              "name": "my-field",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+        },
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 5,
+                "line": 18,
+              },
+              "start": Object {
+                "column": 4,
+                "line": 16,
               },
             },
           },
@@ -19266,11 +19373,11 @@ Array [
           "loc": Object {
             "end": Object {
               "column": 7,
-              "line": 13,
+              "line": 15,
             },
             "start": Object {
               "column": 4,
-              "line": 9,
+              "line": 11,
             },
           },
           "memberof": "TheClass",
@@ -19451,11 +19558,11 @@ Array [
             "loc": Object {
               "end": Object {
                 "column": 5,
-                "line": 24,
+                "line": 26,
               },
               "start": Object {
                 "column": 4,
-                "line": 22,
+                "line": 24,
               },
             },
           },
@@ -19517,11 +19624,11 @@ Array [
           "loc": Object {
             "end": Object {
               "column": 7,
-              "line": 21,
+              "line": 23,
             },
             "start": Object {
               "column": 4,
-              "line": 17,
+              "line": 19,
             },
           },
           "memberof": "TheClass",
@@ -19795,6 +19902,51 @@ Object {
           "column": 19,
           "line": 1,
           "offset": 18,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "my-field",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 9,
+              "line": 1,
+              "offset": 8,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "My field",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 9,
+          "line": 1,
+          "offset": 8,
         },
         "indent": Array [],
         "start": Object {

--- a/__tests__/fixture/lends.input.js
+++ b/__tests__/fixture/lends.input.js
@@ -6,6 +6,8 @@
 export default TheClass(
   /** @lends TheClass.prototype */
   {
+    /** My field */
+    'my-field': true,
     /**
      * My neat function
      * @param {string} word your word

--- a/src/infer/membership.js
+++ b/src/infer/membership.js
@@ -280,7 +280,10 @@ module.exports = function() {
     }
 
     // Same as above but for `b: c` vs `b: function () {}`.
-    if (path.isObjectProperty() && path.get('key').isIdentifier()) {
+    if (
+      path.isObjectProperty() &&
+      (path.get('key').isIdentifier() || path.get('key').isLiteral())
+    ) {
       path = path.get('key');
     }
 
@@ -357,7 +360,7 @@ module.exports = function() {
     let objectParent;
 
     if (
-      path.isIdentifier() &&
+      (path.isIdentifier() || path.isLiteral()) &&
       path.parentPath.isObjectProperty() &&
       path.parentPath.parentPath.isObjectExpression()
     ) {


### PR DESCRIPTION
Good day,

This MR closes #840

At the moment if object property key is a literal it will not be processed correctly because conditions check for `NodePath.isIdentifier()`.