### PR TITLE
test: Make tests resilient between versions: no more annoying chores

### DIFF
--- a/__tests__/__snapshots__/bin.js.snap
+++ b/__tests__/__snapshots__/bin.js.snap
@@ -5,7 +5,7 @@ exports[`--config 1`] = `
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>documentation 6.0.0 | Documentation</title>
+  <title> | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -17,7 +17,7 @@ exports[`--config 1`] = `
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>documentation</h3>
-          <div class='mb1'><code>6.0.0</code></div>
+          <div class='mb1'><code>6.1.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -827,7 +827,7 @@ exports[`html nested.input.js 1`] = `
 <html>
 <head>
   <meta charset='utf-8' />
-  <title>documentation 6.0.0 | Documentation</title>
+  <title> | Documentation</title>
   <meta name='viewport' content='width=device-width,initial-scale=1'>
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
@@ -839,7 +839,7 @@ exports[`html nested.input.js 1`] = `
       <div id='split-left' class='overflow-auto fs0 height-viewport-100'>
         <div class='py1 px2'>
           <h3 class='mb0 no-anchor'>documentation</h3>
-          <div class='mb1'><code>6.0.0</code></div>
+          <div class='mb1'><code>6.1.0</code></div>
           <input
             placeholder='Filter'
             id='filter-input'

--- a/__tests__/bin.js
+++ b/__tests__/bin.js
@@ -171,7 +171,8 @@ test('--config', async function() {
     {},
     false
   );
-  const output = fs.readFileSync(outputIndex, 'utf8');
+  let output = fs.readFileSync(outputIndex, 'utf8');
+  output = output.replace(/documentation \d+\.\d+\.\d+/g, '');
   expect(output).toMatchSnapshot();
 });
 

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -103,7 +103,9 @@ describe('html', function() {
         const clean = html
           .sort((a, b) => a.path > b.path)
           .filter(r => r.path.match(/(html)$/))
-          .map(r => r.contents)
+          .map(r =>
+            r.contents.toString().replace(/documentation \d+\.\d+\.\d+/g, '')
+          )
           .join('\n');
         expect(clean).toMatchSnapshot();
       });


### PR DESCRIPTION
Our tests test _against_ documentation.js itself. Which is neat, but has the disadvantage that they include the version number of documentation.js, so every time that we release a version, the tests break because the version number doesn't match.

This PR that I should have written a long time ago sanitizes that version number, so tests continue to pass even when we release new versions.