### PR TITLE
fix: get rid of shelljs dependency

### DIFF
--- a/__tests__/lib/input/dependency.js
+++ b/__tests__/lib/input/dependency.js
@@ -1,5 +1,4 @@
 const os = require('os');
-const shell = require('shelljs');
 const path = require('path');
 const fs = require('fs');
 const dependency = require('../../../src/input/dependency');

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "remark-reference-links": "^4.0.1",
     "remark-toc": "^5.0.0",
     "remote-origin-url": "0.4.0",
-    "shelljs": "^0.8.1",
     "stream-array": "^1.1.2",
     "strip-json-comments": "^2.0.1",
     "tiny-lr": "^1.1.0",

--- a/src/smart_glob.js
+++ b/src/smart_glob.js
@@ -2,7 +2,6 @@
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
-const shell = require('shelljs');
 
 /**
  * Replace Windows with posix style paths
@@ -59,7 +58,10 @@ function processPath(extensions) {
     let newPath = pathname;
     const resolvedPath = path.resolve(cwd, pathname);
 
-    if (shell.test('-d', resolvedPath)) {
+    if (
+      fs.existsSync(resolvedPath) &&
+      fs.lstatSync(resolvedPath).isDirectory()
+    ) {
       newPath = pathname.replace(/[/\\]$/, '') + suffix;
     }
 
@@ -107,7 +109,7 @@ function listFilesToProcess(globPatterns: Array<string>): Array<string> {
 
   globPatterns.forEach(function(pattern) {
     const file = path.resolve(cwd, pattern);
-    if (shell.test('-f', file)) {
+    if (fs.existsSync(file) && fs.statSync(file).isFile()) {
       addFile(fs.realpathSync(file));
     } else {
       const globOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,7 +2694,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -2979,10 +2979,6 @@ inquirer@^3.0.6:
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
-
-interpret@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
 invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
@@ -5167,12 +5163,6 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -5470,7 +5460,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.3, resolve@^1.1.6:
+resolve@^1.1.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
@@ -5600,14 +5590,6 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-shelljs@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.1.tgz#729e038c413a2254c4078b95ed46e0397154a9f1"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
This is #1044 rebased on top of #1045 to fix tests.