### PR TITLE
chore(package): Update lodash, to keep david-dm from crying wolf about security

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "globals-docs": "^2.4.0",
     "highlight.js": "^9.12.0",
     "js-yaml": "^3.10.0",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "mdast-util-inject": "^1.1.0",
     "micromatch": "^3.1.5",
     "mime": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,6 +4159,10 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, l
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
 lodash@^4.17.5:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"


### PR DESCRIPTION
I’m strongly considering removing David DM, because it yields so many false positives - reports that
only apply in the narrowest circumstances that don’t ever occur in my projects.