### PR TITLE
feat: support flow comment types

### DIFF
--- a/__tests__/fixture/flow/comment-types.js
+++ b/__tests__/fixture/flow/comment-types.js
@@ -1,0 +1,17 @@
+// @flow
+
+/*::
+type Foo = {
+  foo: number,
+  bar: boolean,
+  baz: string
+};
+*/
+
+class MyClass {
+  /*:: prop: Foo; */
+
+  method(value /*: Foo */) /*: boolean */ {
+    return value.bar;
+  }
+}

--- a/__tests__/lib/parsers/parse_to_ast.js
+++ b/__tests__/lib/parsers/parse_to_ast.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const {
+  commentToFlow,
+  parseToAst
+} = require('../../../src/parsers/parse_to_ast');
+
+describe('flow comments', () => {
+  const f = require.resolve('../../fixture/flow/comment-types');
+  const src = fs.readFileSync(f, 'utf8');
+
+  test('preserve line numbers', () => {
+    const out = commentToFlow(src);
+    const linesSrc = src.split(/\n/);
+    const linesOut = out.split(/\n/);
+
+    expect(linesOut).toHaveLength(linesSrc.length);
+    expect(linesSrc[14]).toEqual(linesOut[14]);
+  });
+
+  test('valid js', () => {
+    expect(() => parseToAst(src)).not.toThrowError();
+  });
+});

--- a/src/parsers/parse_to_ast.js
+++ b/src/parsers/parse_to_ast.js
@@ -28,7 +28,7 @@ const opts = {
  * @param {*} source code with flow type comments
  * @returns {string} code with flow annotations
  */
-function commentToFlow(source) {
+export function commentToFlow(source: string) {
   if (!/@flow/.test(source)) return source;
   return source
     .replace(/\/\*::([^]+?)\*\//g, '$1')

--- a/src/parsers/parse_to_ast.js
+++ b/src/parsers/parse_to_ast.js
@@ -21,6 +21,20 @@ const opts = {
   ]
 };
 
+/**
+ * Convert flow comment types into flow annotations so that
+ * they end up in the final AST. If the source does not contain
+ * a flow pragma, the code is returned verbatim.
+ * @param {*} source code with flow type comments
+ * @returns {string} code with flow annotations
+ */
+function commentToFlow(source) {
+  if (!/@flow/.test(source)) return source;
+  return source
+    .replace(/\/\*::([^]+?)\*\//g, '$1')
+    .replace(/\/\*:\s*([^]+?)\s*\*\//g, ':$1');
+}
+
 export function parseToAst(source: string) {
-  return babylon.parse(source, opts);
+  return babylon.parse(commentToFlow(source), opts);
 }


### PR DESCRIPTION
This PR adds support for flow comments types (see #306, #386 and #586) by converting them into regular flow annotations before passing the source on to babylon.

Code that does not include the `@flow` pragma is left untouched.