### PR TITLE
package.json: update git-url-parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "disparity": "^2.0.0",
     "doctrine-temporary-fork": "2.0.1",
     "get-port": "^3.2.0",
-    "git-url-parse": "^9.0.0",
+    "git-url-parse": "^10.0.0",
     "github-slugger": "1.2.0",
     "glob": "^7.1.2",
     "globals-docs": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,12 +2657,11 @@ git-up@^2.0.0:
     is-ssh "^1.3.0"
     parse-url "^1.3.0"
 
-git-url-parse@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-9.0.0.tgz#a82a36acc3544c77ed0984d6488b37fbcfbec24d"
+git-url-parse@^10.0.0:
+  version "10.0.1"
+  resolved "http://npm.corp.arista.io/git-url-parse/-/git-url-parse-10.0.1.tgz#75f153b24ac7297447fc583cf9fac23a5ae687c1"
   dependencies:
     git-up "^2.0.0"
-    parse-domain "^2.0.0"
 
 gitconfiglocal@^1.0.0:
   version "1.0.0"
@@ -4859,10 +4858,6 @@ parents@^1.0.0:
   resolved "https://registry.yarnpkg.com/parents/-/parents-1.0.1.tgz#fedd4d2bf193a77745fe71e371d73c3307d9c751"
   dependencies:
     path-platform "~0.11.15"
-
-parse-domain@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/parse-domain/-/parse-domain-2.0.0.tgz#e9f42f697c30f7c2051dc5c55ff4d8a80da7943c"
 
 parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
parse-domain issue: https://github.com/peerigon/parse-domain/issues/35 has not been fixed,
but git-url-parse removed that dependency in version 10: https://github.com/IonicaBizau/git-url-parse/pull/80