### PR TITLE
markdown_ast include comment.kind in heading (for each node)

### DIFF
--- a/src/output/markdown_ast.js
+++ b/src/output/markdown_ast.js
@@ -317,7 +317,16 @@ function buildMarkdownAST(
         .filter(Boolean);
     }
 
-    return [u('heading', { depth }, [u('text', comment.name || '')])]
+    return [
+      u(
+        'heading',
+        { depth },
+        (comment.kind
+          ? [u('emphasis', [u('text', comment.kind)]), u('text', ' ')]
+          : []
+        ).concat([u('text', comment.name || '')])
+      )
+    ]
       .concat(githubLink(comment))
       .concat(augmentsLink(comment))
       .concat(seeLink(comment))


### PR DESCRIPTION
Markdown output won't include anything that clearly reveals the kind of a named item.
You have to analyse the output (by looking at the naming or at the displayed subheadings) to figure out if something is a class, a function, etc.

My proposal:

before:
```md
## myClass

## myFunc
```

after:
```md
## _class_ myClass

## _function_ myFunc
```

Works great for me. Next step could be adding a cli option to turn this on or off.