### PR TITLE
feat: added project description (fix: #1039)

### DIFF
--- a/__tests__/__snapshots__/bin.js.snap
+++ b/__tests__/__snapshots__/bin.js.snap
@@ -11,6 +11,7 @@ exports[`--config 1`] = `
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
   <link href='assets/github.css' type='text/css' rel='stylesheet' />
   <link href='assets/split.css' type='text/css' rel='stylesheet' />
+  <meta name='description' content='a documentation generator'>
 </head>
 <body class='documentation m0'>
     <div class='flex'>

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -1393,6 +1393,7 @@ exports[`html nested.input.js 1`] = `
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
   <link href='assets/github.css' type='text/css' rel='stylesheet' />
   <link href='assets/split.css' type='text/css' rel='stylesheet' />
+  <meta name='description' content='a documentation generator'>
 </head>
 <body class='documentation m0'>
     <div class='flex'>

--- a/__tests__/lib/merge_config.js
+++ b/__tests__/lib/merge_config.js
@@ -17,7 +17,8 @@ test('right merging package configuration', async function() {
     'no-package',
     'parseExtension',
     'project-homepage',
-    'project-version'
+    'project-version',
+    'project-description'
   ]);
   return mergeConfig({
     config: path.join(__dirname, '../config_fixture/config.json'),
@@ -41,7 +42,8 @@ test('nc(mergeConfig)', async function() {
     'parseExtension',
     'project-homepage',
     'project-name',
-    'project-version'
+    'project-version',
+    'project-description'
   ]);
 
   return Promise.all(

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -20,6 +20,8 @@ Options:
                              package.json
   --project-version          project version. by default, inferred from
                              package.json
+  --project-description      project description. by default, inferred from
+                             package.json
   --project-homepage         project homepage. by default, inferred from
                              package.json
   --watch, -w                watch input files and rebuild documentation when

--- a/src/commands/shared_options.js
+++ b/src/commands/shared_options.js
@@ -97,6 +97,9 @@ module.exports.sharedOutputOptions = {
   'project-version': {
     describe: 'project version. by default, inferred from package.json'
   },
+  'project-description': {
+    describe: 'project description. by default, inferred from package.json'
+  },
   'project-homepage': {
     describe: 'project homepage. by default, inferred from package.json'
   },

--- a/src/default_theme/index._
+++ b/src/default_theme/index._
@@ -7,7 +7,8 @@
   <link href='assets/bass.css' type='text/css' rel='stylesheet' />
   <link href='assets/style.css' type='text/css' rel='stylesheet' />
   <link href='assets/github.css' type='text/css' rel='stylesheet' />
-  <link href='assets/split.css' type='text/css' rel='stylesheet' />
+  <link href='assets/split.css' type='text/css' rel='stylesheet' /><% if (config['project-description']) { %>
+  <meta name='description' content='<%- config['project-description'] %>'><% } %>
 </head>
 <body class='documentation m0'>
     <div class='flex'>

--- a/src/merge_config.js
+++ b/src/merge_config.js
@@ -38,7 +38,7 @@ function mergePackage(config: Object): Promise<Object> {
   return (
     readPkgUp()
       .then(pkg => {
-        ['name', 'homepage', 'version'].forEach(key => {
+        ['name', 'homepage', 'version', 'description'].forEach(key => {
           config[`project-${key}`] = config[`project-${key}`] || pkg.pkg[key];
         });
         return config;


### PR DESCRIPTION
This pull request integrates that it is possible to add a project description (fix: #1039). This will be default inherit from the `package.json` and can be optional given by the `--project-description` flag. Currently it is only used as a meta description for SEO (Google, ...). But I think it also makes sense to add it to the default template and position it under the header like that:
![image](https://user-images.githubusercontent.com/17984549/43632236-d22094ce-9705-11e8-8ced-213964687e6a.png)

But that's not yet implemented in this PR.
