### PR TITLE
Fix membership infering for methods

### DIFF
--- a/__tests__/lib/infer/membership.js
+++ b/__tests__/lib/infer/membership.js
@@ -279,6 +279,38 @@ test('inferMembership - explicit', function() {
   expect(
     pick(
       evaluate(function() {
+        /** @memberof bar */
+        class Foo {
+          /** */
+          baz() {}
+        }
+      })[1], // [0] is an description for class Foo
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'bar.Foo',
+    scope: 'instance'
+  });
+
+  expect(
+    pick(
+      evaluate(function() {
+        /** @memberof bar */
+        class Foo {
+          /** */
+          static baz() {}
+        }
+      })[1], // [0] is an description for class Foo
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'bar.Foo',
+    scope: 'static'
+  });
+
+  expect(
+    pick(
+      evaluate(function() {
         /** Test */
         module.exports = function() {};
       })[0],


### PR DESCRIPTION
This PR resolves #1121.
Improve inferMembership to allow to use next code:
```js
/**
 * @memberof BigFeature
 */
class MyClass {
  /** method */
  method() {}
}
```
Before this improvement, we have `method` inside
 `global.MyClass` instead of `global.BigFeature.MyClass`