### PR TITLE
feat: support spead types

### DIFF
--- a/__tests__/lib/flow_doctrine.js
+++ b/__tests__/lib/flow_doctrine.js
@@ -300,6 +300,11 @@ test('flowDoctrine', function() {
     name: 'this'
   });
 
+  expect(toDoctrineType('{ ...A }')).toEqual({
+    fields: [],
+    type: 'RecordType'
+  });
+
   // TODO: remove all these types
   expect(types).toEqual([
     'ExistsTypeAnnotation',

--- a/src/flow_doctrine.js
+++ b/src/flow_doctrine.js
@@ -16,6 +16,8 @@ const oneToOne = {
 };
 
 function propertyToField(property) {
+  if (!property.value) return null;
+
   let type = flowDoctrine(property.value);
   if (property.optional) {
     // Doctrine does not support optional fields but it does have something called optional types
@@ -127,7 +129,7 @@ function flowDoctrine(type: Object): DoctrineType {
       if (type.properties) {
         return {
           type: 'RecordType',
-          fields: type.properties.map(propertyToField)
+          fields: type.properties.map(propertyToField).filter(x => x)
         };
       }
 


### PR DESCRIPTION
This adds support for spread expressions within Object type. I did not find a way to express this as a doctrine AST. So I'm just dropping these spread fields. If anyone has a better idea, I'm open to suggestions. But this PR would at least fix the problem, that the builder crashes if you have such an expression in your code.