### PR TITLE
fix: inferred properties duplicating explicitly specified ones

### DIFF
--- a/__tests__/lib/infer/properties.js
+++ b/__tests__/lib/infer/properties.js
@@ -30,6 +30,20 @@ test('inferProperties', function() {
   ]);
 
   expect(
+    evaluate('/** @property {number} b */ type a = { b: 1 };').properties
+  ).toEqual([
+    {
+      lineNumber: 0,
+      name: 'b',
+      title: 'property',
+      type: {
+        name: 'number',
+        type: 'NameExpression'
+      }
+    }
+  ]);
+
+  expect(
     evaluate('/** */interface a { b: 1, c: { d: 2 } };').properties
   ).toEqual([
     {

--- a/src/infer/properties.js
+++ b/src/infer/properties.js
@@ -35,7 +35,7 @@ function inferProperties(comment) {
   const explicitProperties = new Set();
   // Ensure that explicitly specified properties are not overridden
   // by inferred properties
-  comment.properties.forEach(prop => explicitProperties.add(prop));
+  comment.properties.forEach(prop => explicitProperties.add(prop.name));
 
   function inferProperties(value, prefix) {
     if (value.type === 'ObjectTypeAnnotation') {


### PR DESCRIPTION
Fixing issue mentioned in this comment: https://github.com/documentationjs/documentation/issues/843#issuecomment-318009351

When property is declared in comment for type definition, its duplicated by inferred property - code handling this was already there, but checking if property name is present in the set was broken.