### PR TITLE
Support custom babel config

### DIFF
--- a/src/commands/shared_options.js
+++ b/src/commands/shared_options.js
@@ -2,6 +2,12 @@
  * Adds shared options to any command that runs documentation
  */
 module.exports.sharedInputOptions = {
+  babel: {
+    describe:
+      'path to babelrc or babel.options.js to override default babel config',
+    type: 'string',
+    default: null
+  },
   shallow: {
     describe:
       'shallow mode turns off dependency resolution, ' +


### PR DESCRIPTION
**Proposal:**

Allow users to support their own babel configuration via new cli option:

```
documentation build --babel=./babel.config.js
```

Aims to resolve: https://github.com/documentationjs/documentation/issues/1149, https://github.com/documentationjs/documentation/issues/140

This will need some refinement of implementation, but if the overall concept is acceptable, that should be easy to resolve.