### PR TITLE
Adding markdown-toc-max-depth

### DIFF
--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -14,6 +14,7 @@ type DocumentationConfig = {
   parseExtension: Array<string>,
   noReferenceLinks?: boolean,
   markdownToc?: boolean,
+  markdownTocMaxDepth?: number,
   documentExported?: boolean,
   resolve?: string,
   hljs?: Object

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,6 +29,8 @@ Options:
                              they change                               [boolean]
   --markdown-toc             include a table of contents in markdown output
                                                        [boolean] [default: true]
+  --markdown-toc-max-depth   specifies the max depth of the table of contents in markdown output
+                                                           [number] [default: 6]
   --shallow                  shallow mode turns off dependency resolution, only
                              processing the specified files (or the main script
                              specified in package.json)

--- a/src/commands/shared_options.js
+++ b/src/commands/shared_options.js
@@ -123,5 +123,11 @@ module.exports.sharedOutputOptions = {
     describe: 'include a table of contents in markdown output',
     default: true,
     type: 'boolean'
+  },
+  'markdown-toc-max-depth': {
+    describe:
+      'specifies the max depth of the table of contents in markdown output',
+    default: 6,
+    type: 'number'
   }
 };

--- a/src/output/markdown_ast.js
+++ b/src/output/markdown_ast.js
@@ -371,7 +371,11 @@ function buildMarkdownAST(comments, config) {
   );
 
   const pluginRemark = remark();
-  if (config.markdownToc) pluginRemark.use(toc, { tight: true });
+  if (config.markdownToc)
+    pluginRemark.use(toc, {
+      tight: true,
+      maxDepth: config.markdownTocMaxDepth
+    });
   if (config.noReferenceLinks !== true) pluginRemark.use(links);
   root = pluginRemark.run(root);
 


### PR DESCRIPTION
I'm adding an additional cli option, `markdown-toc-max-depth` for configuring the plguin,`markdown-toc`'s `maxDepth` argument. This is useful if we want to control the depth of the `table of content`.

This shouldn't introduce any regression because it's just an extra configuration on top of `markdown-toc`.

I'm unfamiliar with writing tests for this particular kind of stuff . Therefore, I was only able to confirm manually. I would be more than happy to include some tests if someone want to lend me a hand. :)

Address #1101 