### PR TITLE
THEMING.md line number is incorrect

### DIFF
--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -29,7 +29,7 @@ for some ideas.
 
 - Copy contents of `default_theme` folder (noted above) into a new folder in your project.  One way to do it is to create a new git repository with the folder contents and add this line to your `package.json` `devDependencies` section:    `"docjs-theme": "my-gh-username/reponame"`.   That way when you install dependencies, your new theme will be in the projects `node_modules` folder.
 
-- In the folder you created, replace `require('../')` on lines 10 and 11 of `index.js` with `require('documentation')` and save.
+- In the folder you created, replace `require('../')` on lines 8 and 9 of `index.js` with `require('documentation')` and save.
 
 - You can now make changes that will show up when you generate your docs using your theme.   Example `package.json` `scripts` entry: `"documentation build index.js -f html -o docs --theme node_modules/docjs-theme"`
 


### PR DESCRIPTION
Now 

> In the folder you created, replace require('../') on lines 10 and 11 of index.js with require('documentation') and save.

ref: https://github.com/documentationjs/documentation/blob/64ef671d993922821daf8e18d7dc28cdeaa1614a/docs/THEMING.md#customizing-the-default-theme

`10 and 11 of index.js` should be `8 and 9 of index.js`.