### PR TITLE
TypeScript support

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -58,6 +58,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": SourceLocation {
       "end": Position {
         "column": 9,
@@ -172,6 +173,7 @@ exports[`build 3`] = `
     },
     \\"augments\\": [],
     \\"examples\\": [],
+    \\"implements\\": [],
     \\"params\\": [],
     \\"properties\\": [],
     \\"returns\\": [],

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -74,6 +74,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "loc": SourceLocation {
       "end": Position {
         "column": 3,
@@ -246,6 +247,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": SourceLocation {
       "end": Position {
         "column": 7,
@@ -353,6 +355,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": SourceLocation {
       "end": Position {
         "column": 3,
@@ -525,6 +528,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": SourceLocation {
       "end": Position {
         "column": 5,
@@ -768,6 +772,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": SourceLocation {
       "end": Position {
@@ -871,6 +876,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": SourceLocation {
       "end": Position {
@@ -1044,6 +1050,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": SourceLocation {
       "end": Position {
@@ -1226,6 +1233,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": SourceLocation {
       "end": Position {
@@ -2899,6 +2907,7 @@ Array [
 // result is 6",
       },
     ],
+    "implements": Array [],
     "kind": "function",
     "loc": SourceLocation {
       "end": Position {
@@ -3150,6 +3159,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": SourceLocation {
       "end": Position {
@@ -3277,6 +3287,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -3499,11 +3510,11 @@ Array [
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 8,
+          "line": 9,
         },
         "start": Object {
           "column": 0,
-          "line": 6,
+          "line": 7,
         },
       },
     },
@@ -3561,11 +3572,23 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [
+      Object {
+        "description": null,
+        "lineNumber": 3,
+        "name": "MyInterface",
+        "title": "implements",
+        "type": Object {
+          "name": "MyInterface",
+          "type": "NameExpression",
+        },
+      },
+    ],
     "kind": "class",
     "loc": Object {
       "end": Object {
         "column": 3,
-        "line": 5,
+        "line": 6,
       },
       "start": Object {
         "column": 0,
@@ -3583,11 +3606,11 @@ Array [
             "loc": Object {
               "end": Object {
                 "column": 2,
-                "line": 17,
+                "line": 18,
               },
               "start": Object {
                 "column": 0,
-                "line": 15,
+                "line": 16,
               },
             },
           },
@@ -3645,15 +3668,16 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
               "column": 3,
-              "line": 14,
+              "line": 15,
             },
             "start": Object {
               "column": 0,
-              "line": 10,
+              "line": 11,
             },
           },
           "memberof": "MyClass",
@@ -3835,11 +3859,11 @@ Array [
             "loc": Object {
               "end": Object {
                 "column": 47,
-                "line": 23,
+                "line": 24,
               },
               "start": Object {
                 "column": 0,
-                "line": 23,
+                "line": 24,
               },
             },
           },
@@ -3897,15 +3921,16 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
               "column": 3,
-              "line": 22,
+              "line": 23,
             },
             "start": Object {
               "column": 0,
-              "line": 19,
+              "line": 20,
             },
           },
           "memberof": "MyClass",
@@ -4073,7 +4098,7 @@ Array [
           },
           "type": "root",
         },
-        "lineNumber": 3,
+        "lineNumber": 4,
         "name": "howMany",
         "title": "property",
         "type": Object {
@@ -4093,8 +4118,18 @@ Array [
         "type": null,
       },
       Object {
-        "description": "how many things it contains",
+        "description": null,
         "lineNumber": 3,
+        "name": "MyInterface",
+        "title": "implements",
+        "type": Object {
+          "name": "MyInterface",
+          "type": "NameExpression",
+        },
+      },
+      Object {
+        "description": "how many things it contains",
+        "lineNumber": 4,
         "name": "howMany",
         "title": "property",
         "type": Object {
@@ -4653,6 +4688,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -4761,6 +4797,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -4925,6 +4962,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -4958,6 +4996,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -5037,6 +5076,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -5095,6 +5135,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -5128,6 +5169,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -5187,6 +5229,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -5246,6 +5289,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -5313,6 +5357,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -5372,6 +5417,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -5431,6 +5477,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -5525,6 +5572,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -5581,6 +5629,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 18,
@@ -5682,6 +5731,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -5751,6 +5801,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 2,
@@ -5784,6 +5835,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -5842,6 +5894,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -5900,6 +5953,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -5964,6 +6018,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "loc": Object {
             "end": Object {
               "column": 10,
@@ -6020,6 +6075,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -6096,6 +6152,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -6148,6 +6205,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -6200,6 +6258,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -6256,6 +6315,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -6312,6 +6372,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -6368,6 +6429,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -6430,6 +6492,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 2,
@@ -6463,6 +6526,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -6590,6 +6654,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -6652,6 +6717,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -6685,6 +6751,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -7624,6 +7691,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 2,
@@ -7679,6 +7747,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 7,
@@ -7771,6 +7840,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 18,
@@ -7906,6 +7976,7 @@ have any parameter descriptions.",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -8046,6 +8117,7 @@ have any parameter descriptions.",
         "description": "destructure([1, 2, 3])",
       },
     ],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -8182,6 +8254,7 @@ have any parameter descriptions.",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -8458,6 +8531,7 @@ class A {
 }",
       },
     ],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -8542,6 +8616,7 @@ class A {
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -8652,6 +8727,7 @@ class A {
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -8762,6 +8838,7 @@ class A {
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -8895,6 +8972,7 @@ as a property.",
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -9007,6 +9085,7 @@ as a property.",
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -9289,6 +9368,7 @@ class A {
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -9551,6 +9631,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -9724,6 +9805,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -9836,6 +9918,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -9953,6 +10036,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -10056,6 +10140,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -10229,6 +10314,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -10340,6 +10426,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -10450,6 +10537,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -10559,6 +10647,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -10660,6 +10749,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -10839,6 +10929,7 @@ It takes a ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -13496,6 +13587,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -13599,6 +13691,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -13683,6 +13776,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "loc": Object {
             "end": Object {
               "column": 7,
@@ -13846,6 +13940,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -14397,6 +14492,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -14481,6 +14577,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -14605,6 +14702,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -14911,6 +15009,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -15093,6 +15192,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -15272,6 +15372,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -15373,6 +15474,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -15872,6 +15974,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "event",
     "loc": Object {
       "end": Object {
@@ -16444,6 +16547,7 @@ Array [
         "description": "foo(1);",
       },
     ],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -16863,6 +16967,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -17064,6 +17169,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -17186,6 +17292,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -17302,6 +17409,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -17648,6 +17756,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "constant",
     "loc": Object {
       "end": Object {
@@ -17815,6 +17924,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 9,
@@ -17933,6 +18043,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -18071,6 +18182,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -18586,6 +18698,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -18670,6 +18783,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -18914,6 +19028,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -18966,6 +19081,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -19169,6 +19285,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -19596,6 +19713,7 @@ and ",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -20415,6 +20533,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "interface",
     "loc": Object {
       "end": Object {
@@ -20499,6 +20618,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -20613,6 +20733,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "member",
           "loc": Object {
             "end": Object {
@@ -21005,6 +21126,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -21214,6 +21336,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -21298,6 +21421,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "loc": Object {
             "end": Object {
               "column": 19,
@@ -21406,6 +21530,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -21658,6 +21783,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -22423,6 +22549,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -22546,6 +22673,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -22918,6 +23046,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -23003,6 +23132,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -23257,6 +23387,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -23890,6 +24021,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -24438,6 +24570,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "license": "BSD",
     "loc": Object {
@@ -25310,6 +25443,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -25489,6 +25623,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -26108,6 +26243,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -27122,6 +27258,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -27485,6 +27622,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -28940,6 +29078,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -29290,6 +29429,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -29480,6 +29620,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -29821,6 +29962,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -30033,6 +30175,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -30235,6 +30378,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -30360,6 +30504,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -30444,6 +30589,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -30647,6 +30793,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 3,
@@ -30731,6 +30878,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -30903,6 +31051,7 @@ Array [
         "description": "var address = new Address6('2001::/32');",
       },
     ],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -31357,6 +31506,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -31878,6 +32028,7 @@ values specified in code.",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "constant",
     "loc": Object {
       "end": Object {
@@ -32129,6 +32280,7 @@ or any type information we could infer from annotations.",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -32303,6 +32455,7 @@ iterator destructure (RestElement)",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -35248,6 +35401,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -35447,6 +35601,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -35550,6 +35705,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -35609,6 +35765,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -35698,6 +35855,7 @@ that doesn't crash anything!",
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -35828,6 +35986,7 @@ that doesn't crash anything!",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -35912,6 +36071,7 @@ that doesn't crash anything!",
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -36028,6 +36188,7 @@ that doesn't crash anything!",
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -36169,6 +36330,7 @@ that doesn't crash anything!",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -36719,6 +36881,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -37031,6 +37194,7 @@ plus 3.",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -37278,6 +37442,7 @@ plus 3.",
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "typedef",
     "loc": Object {
       "end": Object {
@@ -38028,6 +38193,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -38388,6 +38554,7 @@ Array [
 // result is 6",
       },
     ],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -38827,6 +38994,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -38860,6 +39028,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -38919,6 +39088,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -38978,6 +39148,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -39037,6 +39208,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -39116,6 +39288,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -39149,6 +39322,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -39208,6 +39382,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -39267,6 +39442,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -39326,6 +39502,7 @@ Array [
           "description": "",
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "kind": "function",
           "loc": Object {
             "end": Object {
@@ -39405,6 +39582,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -39457,6 +39635,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {
@@ -39649,6 +39828,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "constant",
     "loc": Object {
       "end": Object {
@@ -39764,6 +39944,7 @@ Array [
       },
     ],
     "examples": Array [],
+    "implements": Array [],
     "loc": Object {
       "end": Object {
         "column": 5,
@@ -39891,6 +40072,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "module",
     "loc": Object {
       "end": Object {
@@ -39951,6 +40133,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -40035,6 +40218,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "loc": Object {
             "end": Object {
               "column": 31,
@@ -40125,6 +40309,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -40209,6 +40394,7 @@ Array [
           },
           "errors": Array [],
           "examples": Array [],
+          "implements": Array [],
           "loc": Object {
             "end": Object {
               "column": 36,
@@ -40565,6 +40751,7 @@ Array [
     },
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "class",
     "loc": Object {
       "end": Object {
@@ -40899,6 +41086,7 @@ Array [
     "description": "",
     "errors": Array [],
     "examples": Array [],
+    "implements": Array [],
     "kind": "function",
     "loc": Object {
       "end": Object {

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -245,7 +245,12 @@ Array [
       },
       "type": "root",
     },
-    "errors": Array [],
+    "errors": Array [
+      Object {
+        "commentLineNumber": 0,
+        "message": "@memberof reference to .props not found",
+      },
+    ],
     "examples": Array [],
     "implements": Array [],
     "loc": SourceLocation {
@@ -258,6 +263,7 @@ Array [
         "line": 10,
       },
     },
+    "memberof": ".props",
     "members": Object {
       "events": Array [],
       "global": Array [],
@@ -266,16 +272,18 @@ Array [
       "static": Array [],
     },
     "name": "myNumber",
-    "namespace": "myNumber",
+    "namespace": ".myNumber",
     "params": Array [],
     "path": Array [
       Object {
         "kind": undefined,
         "name": "myNumber",
+        "scope": "static",
       },
     ],
     "properties": Array [],
     "returns": Array [],
+    "scope": "static",
     "sees": Array [],
     "tags": Array [],
     "throws": Array [],
@@ -293,7 +301,7 @@ Array [
       "loc": SourceLocation {
         "end": Position {
           "column": 1,
-          "line": 19,
+          "line": 20,
         },
         "start": Position {
           "column": 0,
@@ -465,12 +473,12 @@ Array [
     "context": Object {
       "loc": SourceLocation {
         "end": Position {
-          "column": 3,
-          "line": 17,
+          "column": 1,
+          "line": 19,
         },
         "start": Position {
-          "column": 2,
-          "line": 14,
+          "column": 0,
+          "line": 10,
         },
       },
     },
@@ -481,9 +489,9 @@ Array [
             Object {
               "position": Position {
                 "end": Object {
-                  "column": 17,
+                  "column": 6,
                   "line": 1,
-                  "offset": 16,
+                  "offset": 5,
                 },
                 "indent": Array [],
                 "start": Object {
@@ -493,14 +501,14 @@ Array [
                 },
               },
               "type": "text",
-              "value": "This is a number",
+              "value": "props",
             },
           ],
           "position": Position {
             "end": Object {
-              "column": 17,
+              "column": 6,
               "line": 1,
-              "offset": 16,
+              "offset": 5,
             },
             "indent": Array [],
             "start": Object {
@@ -514,9 +522,9 @@ Array [
       ],
       "position": Object {
         "end": Object {
-          "column": 17,
+          "column": 6,
           "line": 1,
-          "offset": 16,
+          "offset": 5,
         },
         "start": Object {
           "column": 1,
@@ -526,37 +534,157 @@ Array [
       },
       "type": "root",
     },
-    "errors": Array [],
+    "errors": Array [
+      Object {
+        "commentLineNumber": 0,
+        "message": "@memberof reference to vue.input not found",
+      },
+    ],
     "examples": Array [],
     "implements": Array [],
     "loc": SourceLocation {
       "end": Position {
-        "column": 5,
-        "line": 13,
+        "column": 12,
+        "line": 9,
       },
       "start": Position {
-        "column": 2,
-        "line": 11,
+        "column": 0,
+        "line": 9,
       },
     },
+    "memberof": "vue.input",
     "members": Object {
       "events": Array [],
       "global": Array [],
       "inner": Array [],
       "instance": Array [],
-      "static": Array [],
+      "static": Array [
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 3,
+                "line": 18,
+              },
+              "start": Position {
+                "column": 2,
+                "line": 15,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Position {
+                      "end": Object {
+                        "column": 17,
+                        "line": 1,
+                        "offset": 16,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "This is a number",
+                  },
+                ],
+                "position": Position {
+                  "end": Object {
+                    "column": 17,
+                    "line": 1,
+                    "offset": 16,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 17,
+                "line": 1,
+                "offset": 16,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "implements": Array [],
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 5,
+              "line": 14,
+            },
+            "start": Position {
+              "column": 2,
+              "line": 12,
+            },
+          },
+          "memberof": "vue.input.props",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "myNumber",
+          "namespace": ".props.myNumber",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": undefined,
+              "name": "props",
+              "scope": "static",
+            },
+            Object {
+              "kind": undefined,
+              "name": "myNumber",
+              "scope": "static",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "static",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "yields": Array [],
+        },
+      ],
     },
-    "name": "myNumber",
-    "namespace": "myNumber",
+    "name": "props",
+    "namespace": ".props",
     "params": Array [],
     "path": Array [
       Object {
         "kind": undefined,
-        "name": "myNumber",
+        "name": "props",
+        "scope": "static",
       },
     ],
     "properties": Array [],
     "returns": Array [],
+    "scope": "static",
     "sees": Array [],
     "tags": Array [],
     "throws": Array [],

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -20353,7 +20353,7 @@ Array [
       "loc": Object {
         "end": Object {
           "column": 1,
-          "line": 7,
+          "line": 9,
         },
         "start": Object {
           "column": 0,
@@ -20430,7 +20430,236 @@ Array [
       "events": Array [],
       "global": Array [],
       "inner": Array [],
-      "instance": Array [],
+      "instance": Array [
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 6,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 6,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "end": Object {
+                        "column": 15,
+                        "line": 1,
+                        "offset": 14,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "This is prop 1",
+                  },
+                ],
+                "position": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 1,
+                    "offset": 14,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+                "offset": 14,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "kind": "member",
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 5,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 5,
+            },
+          },
+          "memberof": "Foo",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "prop1",
+          "namespace": "Foo#prop1",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "interface",
+              "name": "Foo",
+            },
+            Object {
+              "kind": "member",
+              "name": "prop1",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "type": Object {
+            "name": "number",
+            "type": "NameExpression",
+          },
+          "yields": Array [],
+        },
+        Object {
+          "augments": Array [],
+          "context": Object {
+            "loc": Object {
+              "end": Object {
+                "column": 15,
+                "line": 8,
+              },
+              "start": Object {
+                "column": 2,
+                "line": 8,
+              },
+            },
+          },
+          "description": Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "position": Object {
+                      "end": Object {
+                        "column": 15,
+                        "line": 1,
+                        "offset": 14,
+                      },
+                      "indent": Array [],
+                      "start": Object {
+                        "column": 1,
+                        "line": 1,
+                        "offset": 0,
+                      },
+                    },
+                    "type": "text",
+                    "value": "This is prop 2",
+                  },
+                ],
+                "position": Object {
+                  "end": Object {
+                    "column": 15,
+                    "line": 1,
+                    "offset": 14,
+                  },
+                  "indent": Array [],
+                  "start": Object {
+                    "column": 1,
+                    "line": 1,
+                    "offset": 0,
+                  },
+                },
+                "type": "paragraph",
+              },
+            ],
+            "position": Object {
+              "end": Object {
+                "column": 15,
+                "line": 1,
+                "offset": 14,
+              },
+              "start": Object {
+                "column": 1,
+                "line": 1,
+                "offset": 0,
+              },
+            },
+            "type": "root",
+          },
+          "errors": Array [],
+          "examples": Array [],
+          "kind": "member",
+          "loc": Object {
+            "end": Object {
+              "column": 23,
+              "line": 7,
+            },
+            "start": Object {
+              "column": 2,
+              "line": 7,
+            },
+          },
+          "memberof": "Foo",
+          "members": Object {
+            "events": Array [],
+            "global": Array [],
+            "inner": Array [],
+            "instance": Array [],
+            "static": Array [],
+          },
+          "name": "prop2",
+          "namespace": "Foo#prop2",
+          "params": Array [],
+          "path": Array [
+            Object {
+              "kind": "interface",
+              "name": "Foo",
+            },
+            Object {
+              "kind": "member",
+              "name": "prop2",
+              "scope": "instance",
+            },
+          ],
+          "properties": Array [],
+          "returns": Array [],
+          "scope": "instance",
+          "sees": Array [],
+          "tags": Array [],
+          "throws": Array [],
+          "todos": Array [],
+          "type": Object {
+            "name": "string",
+            "type": "NameExpression",
+          },
+          "yields": Array [],
+        },
+      ],
       "static": Array [],
     },
     "name": "Foo",
@@ -20442,26 +20671,7 @@ Array [
         "name": "Foo",
       },
     ],
-    "properties": Array [
-      Object {
-        "lineNumber": 5,
-        "name": "prop1",
-        "title": "property",
-        "type": Object {
-          "name": "number",
-          "type": "NameExpression",
-        },
-      },
-      Object {
-        "lineNumber": 6,
-        "name": "prop2",
-        "title": "property",
-        "type": Object {
-          "name": "string",
-          "type": "NameExpression",
-        },
-      },
-    ],
+    "properties": Array [],
     "returns": Array [],
     "sees": Array [],
     "tags": Array [],
@@ -20548,7 +20758,7 @@ Object {
       "children": Array [
         Object {
           "type": "text",
-          "value": "Properties",
+          "value": "prop1",
         },
       ],
       "depth": 3,
@@ -20557,84 +20767,122 @@ Object {
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "prop1",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "number",
-                        },
-                      ],
-                      "identifier": "1",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
+          "position": Position {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+              "offset": 14,
             },
-          ],
-          "type": "listItem",
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This is prop 1",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+          "offset": 14,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Type: ",
         },
         Object {
           "children": Array [
             Object {
-              "children": Array [
-                Object {
-                  "type": "inlineCode",
-                  "value": "prop2",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-                Object {
-                  "children": Array [
-                    Object {
-                      "children": Array [
-                        Object {
-                          "type": "text",
-                          "value": "string",
-                        },
-                      ],
-                      "identifier": "2",
-                      "referenceType": "full",
-                      "type": "linkReference",
-                    },
-                  ],
-                  "type": "strong",
-                },
-                Object {
-                  "type": "text",
-                  "value": " ",
-                },
-              ],
-              "type": "paragraph",
+              "type": "text",
+              "value": "number",
             },
           ],
-          "type": "listItem",
+          "identifier": "1",
+          "referenceType": "full",
+          "type": "linkReference",
         },
       ],
-      "ordered": false,
-      "type": "list",
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "prop2",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 15,
+              "line": 1,
+              "offset": 14,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "text",
+          "value": "This is prop 2",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 15,
+          "line": 1,
+          "offset": 14,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Type: ",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "string",
+            },
+          ],
+          "identifier": "2",
+          "referenceType": "full",
+          "type": "linkReference",
+        },
+      ],
+      "type": "paragraph",
     },
     Object {
       "identifier": "1",

--- a/__tests__/fixture/class.input.js
+++ b/__tests__/fixture/class.input.js
@@ -1,6 +1,7 @@
 /**
  * This is my class, a demo thing.
  * @class MyClass
+ * @implements {MyInterface}
  * @property {number} howMany how many things it contains
  */
 function MyClass() {

--- a/__tests__/fixture/interface.input.js
+++ b/__tests__/fixture/interface.input.js
@@ -2,6 +2,8 @@
  * This is my interface.
  */
 interface Foo extends Bar, Baz {
+  /** This is prop 1 */
   prop1: number,
+  /** This is prop 2 */
   prop2: string
 }

--- a/__tests__/fixture/vue.input.vue
+++ b/__tests__/fixture/vue.input.vue
@@ -10,6 +10,7 @@
  */
 export default {
 
+/** props */
 props: {
 
   /**

--- a/__tests__/lib/infer/__snapshots__/params.js.snap
+++ b/__tests__/lib/infer/__snapshots__/params.js.snap
@@ -1,5 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`inferParams (typescript) 1`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "a",
+    "title": "param",
+    "type": Object {
+      "name": "string",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 2`] = `
+Array [
+  Object {
+    "anonymous": true,
+    "name": "$0",
+    "properties": Array [
+      Object {
+        "lineNumber": 1,
+        "name": "$0.0",
+        "title": "param",
+        "type": Object {
+          "name": "string",
+          "type": "NameExpression",
+        },
+      },
+      Object {
+        "lineNumber": 1,
+        "name": "$0.1",
+        "title": "param",
+      },
+      Object {
+        "anonymous": true,
+        "name": "$0.2",
+        "properties": Array [
+          Object {
+            "lineNumber": 1,
+            "name": "$0.2.c",
+            "title": "param",
+          },
+        ],
+        "title": "param",
+        "type": Object {
+          "name": "Object",
+          "type": "NameExpression",
+        },
+      },
+    ],
+    "title": "param",
+    "type": Object {
+      "name": "Array",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 3`] = `
+Array [
+  Object {
+    "default": "4",
+    "lineNumber": 1,
+    "name": "x",
+    "title": "param",
+    "type": Object {
+      "name": "number",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 4`] = `
+Array [
+  Object {
+    "lineNumber": 3,
+    "name": "opts",
+    "title": "param",
+    "type": Object {
+      "fields": Array [
+        Object {
+          "key": "x",
+          "type": "FieldType",
+          "value": Object {
+            "name": "string",
+            "type": "NameExpression",
+          },
+        },
+      ],
+      "type": "RecordType",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 5`] = `
+Array [
+  Object {
+    "lineNumber": 3,
+    "name": "opts",
+    "title": "param",
+    "type": Object {
+      "fields": Array [
+        Object {
+          "key": "foo",
+          "type": "FieldType",
+          "value": Object {
+            "name": "string",
+            "type": "NameExpression",
+          },
+        },
+      ],
+      "type": "RecordType",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 6`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "a",
+    "title": "param",
+    "type": Object {
+      "expression": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+      "type": "RestType",
+    },
+  },
+]
+`;
+
 exports[`inferParams 1`] = `
 Array [
   Object {

--- a/__tests__/lib/infer/__snapshots__/params.js.snap
+++ b/__tests__/lib/infer/__snapshots__/params.js.snap
@@ -206,6 +206,51 @@ Array [
 ]
 `;
 
+exports[`inferParams (typescript) 11`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "v",
+    "title": "param",
+    "type": Object {
+      "name": "string",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 12`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "v",
+    "title": "param",
+    "type": Object {
+      "name": "string",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams (typescript) 13`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "v",
+    "title": "param",
+    "type": Object {
+      "expression": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+      "type": "RestType",
+    },
+  },
+]
+`;
+
 exports[`inferParams 1`] = `
 Array [
   Object {
@@ -433,6 +478,51 @@ Array [
     "type": Object {
       "name": "number",
       "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams 9`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "v",
+    "title": "param",
+    "type": Object {
+      "name": "string",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams 10`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "v",
+    "title": "param",
+    "type": Object {
+      "name": "string",
+      "type": "NameExpression",
+    },
+  },
+]
+`;
+
+exports[`inferParams 11`] = `
+Array [
+  Object {
+    "lineNumber": 1,
+    "name": "v",
+    "title": "param",
+    "type": Object {
+      "expression": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+      "type": "RestType",
     },
   },
 ]

--- a/__tests__/lib/infer/__snapshots__/params.js.snap
+++ b/__tests__/lib/infer/__snapshots__/params.js.snap
@@ -172,6 +172,40 @@ Array [
 ]
 `;
 
+exports[`inferParams (typescript) 9`] = `
+Array [
+  Object {
+    "expression": Object {
+      "lineNumber": 1,
+      "name": "a",
+      "title": "param",
+      "type": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+    },
+    "type": "OptionalType",
+  },
+]
+`;
+
+exports[`inferParams (typescript) 10`] = `
+Array [
+  Object {
+    "expression": Object {
+      "lineNumber": 1,
+      "name": "a",
+      "title": "param",
+      "type": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+    },
+    "type": "OptionalType",
+  },
+]
+`;
+
 exports[`inferParams 1`] = `
 Array [
   Object {

--- a/__tests__/lib/infer/__snapshots__/params.js.snap
+++ b/__tests__/lib/infer/__snapshots__/params.js.snap
@@ -138,6 +138,40 @@ Array [
 ]
 `;
 
+exports[`inferParams (typescript) 7`] = `
+Array [
+  Object {
+    "expression": Object {
+      "lineNumber": 1,
+      "name": "a",
+      "title": "param",
+      "type": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+    },
+    "type": "OptionalType",
+  },
+]
+`;
+
+exports[`inferParams (typescript) 8`] = `
+Array [
+  Object {
+    "expression": Object {
+      "lineNumber": 1,
+      "name": "a",
+      "title": "param",
+      "type": Object {
+        "name": "string",
+        "type": "NameExpression",
+      },
+    },
+    "type": "OptionalType",
+  },
+]
+`;
+
 exports[`inferParams 1`] = `
 Array [
   Object {

--- a/__tests__/lib/infer/access.js
+++ b/__tests__/lib/infer/access.js
@@ -2,17 +2,18 @@ const parse = require('../../../src/parsers/javascript');
 const inferName = require('../../../src/infer/name');
 const inferAccess = require('../../../src/infer/access');
 
-function toComment(fn) {
+function toComment(fn, filename) {
   return parse(
     {
-      source: '(' + fn.toString() + ')'
+      file: filename,
+      source: fn instanceof Function ? '(' + fn.toString() + ')' : fn
     },
     {}
   )[0];
 }
 
-function evaluate(fn, re) {
-  return inferAccess(re)(inferName(toComment(fn)));
+function evaluate(fn, re, filename) {
+  return inferAccess(re)(inferName(toComment(fn, filename)));
 }
 
 test('inferAccess', function() {
@@ -43,4 +44,31 @@ test('inferAccess', function() {
       function name_() {}
     }, '_$').access
   ).toBe('private');
+
+  expect(
+    evaluate(`
+      class Test {
+        /** */
+        private foo() {}
+      }
+    `, '_$', 'test.ts').access
+  ).toBe('private');
+
+  expect(
+    evaluate(`
+      class Test {
+        /** */
+        protected foo() {}
+      }
+    `, '_$', 'test.ts').access
+  ).toBe('protected');
+
+  expect(
+    evaluate(`
+      class Test {
+        /** */
+        public foo() {}
+      }
+    `, '_$', 'test.ts').access
+  ).toBe('public');
 });

--- a/__tests__/lib/infer/access.js
+++ b/__tests__/lib/infer/access.js
@@ -71,4 +71,22 @@ test('inferAccess', function() {
       }
     `, '_$', 'test.ts').access
   ).toBe('public');
+
+  expect(
+    evaluate(`
+      class Test {
+        /** */
+        readonly name: string;
+      }
+    `, '_$', 'test.ts').readonly
+  ).toBe(true);
+
+  expect(
+    evaluate(`
+      interface Test {
+        /** */
+        readonly name: string;
+      }
+    `, '_$', 'test.ts').readonly
+  ).toBe(true);
 });

--- a/__tests__/lib/infer/access.js
+++ b/__tests__/lib/infer/access.js
@@ -76,6 +76,15 @@ test('inferAccess', function() {
     evaluate(`
       class Test {
         /** */
+        public abstract foo();
+      }
+    `, '_$', 'test.ts').access
+  ).toBe('public');
+
+  expect(
+    evaluate(`
+      class Test {
+        /** */
         readonly name: string;
       }
     `, '_$', 'test.ts').readonly

--- a/__tests__/lib/infer/augments.js
+++ b/__tests__/lib/infer/augments.js
@@ -12,8 +12,8 @@ function toComment(fn, filename) {
   )[0];
 }
 
-function evaluate(code) {
-  return inferAugments(toComment(code));
+function evaluate(code, filename) {
+  return inferAugments(toComment(code, filename));
 }
 
 test('inferAugments', function() {
@@ -21,6 +21,28 @@ test('inferAugments', function() {
     {
       name: 'B',
       title: 'augments'
+    }
+  ]);
+
+  expect(evaluate('/** */interface A extends B, C {}').augments).toEqual([
+    {
+      name: 'B',
+      title: 'extends'
+    },
+    {
+      name: 'C',
+      title: 'extends'
+    }
+  ]);
+
+  expect(evaluate('/** */interface A extends B, C {}', 'test.ts').augments).toEqual([
+    {
+      name: 'B',
+      title: 'extends'
+    },
+    {
+      name: 'C',
+      title: 'extends'
     }
   ]);
 });

--- a/__tests__/lib/infer/implements.js
+++ b/__tests__/lib/infer/implements.js
@@ -1,0 +1,57 @@
+/*eslint-disable no-unused-vars*/
+const inferImplements = require('../../../src/infer/implements');
+const parse = require('../../../src/parsers/javascript');
+
+function toComment(fn, filename) {
+  return parse(
+    {
+      file: filename,
+      source: fn instanceof Function ? '(' + fn.toString() + ')' : fn
+    },
+    {}
+  )[0];
+}
+
+function evaluate(code, filename) {
+  return inferImplements(toComment(code, filename));
+}
+
+test('inferImplements (flow)', function() {
+  expect(evaluate('/** */class A implements B {}').implements).toEqual([
+    {
+      name: 'B',
+      title: 'implements'
+    }
+  ]);
+
+  expect(evaluate('/** */class A implements B, C {}').implements).toEqual([
+    {
+      name: 'B',
+      title: 'implements'
+    },
+    {
+      name: 'C',
+      title: 'implements'
+    }
+  ]);
+});
+
+test('inferImplements (typescript)', function() {
+  expect(evaluate('/** */class A implements B {}', 'test.ts').implements).toEqual([
+    {
+      name: 'B',
+      title: 'implements'
+    }
+  ]);
+
+  expect(evaluate('/** */class A implements B, C {}', 'test.ts').implements).toEqual([
+    {
+      name: 'B',
+      title: 'implements'
+    },
+    {
+      name: 'C',
+      title: 'implements'
+    }
+  ]);
+});

--- a/__tests__/lib/infer/kind.js
+++ b/__tests__/lib/infer/kind.js
@@ -133,7 +133,7 @@ test('inferKind', function() {
   expect(generatorMethod.kind).toBe('function');
   expect(generatorMethod.generator).toBe(true);
 
-  const abstractMethod = inferKind(toComment('abstract class C { /** */ abstract foo() {} }', 'test.ts'));
+  const abstractMethod = inferKind(toComment('abstract class C { /** */ abstract foo(); }', 'test.ts'));
   expect(abstractMethod.kind).toBe('function');
   expect(abstractMethod.abstract).toBe(true);
 

--- a/__tests__/lib/infer/kind.js
+++ b/__tests__/lib/infer/kind.js
@@ -68,6 +68,11 @@ test('inferKind', function() {
   ).toBe('interface');
 
   expect(
+    inferKind(toComment('/** Exported interface */' + 'interface myinter {}', 'test.ts'))
+      .kind
+  ).toBe('interface');
+
+  expect(
     inferKind(
       toComment(
         '/** Exported interface */' + 'module.exports.foo = function() {}'
@@ -167,4 +172,30 @@ test('inferKind', function() {
       )
     ).kind
   ).toBe('constant');
+
+  expect(
+    inferKind(
+      toComment(
+        '/** */' + 'type Foo = string'
+      )
+    ).kind
+  ).toBe('typedef');
+
+  expect(
+    inferKind(
+      toComment(
+        '/** */' + 'type Foo = string',
+        'test.ts'
+      )
+    ).kind
+  ).toBe('typedef');
+
+  const namespace = inferKind(
+    toComment(
+      '/** */ namespace Test { /** */ export function foo() {} }',
+      'test.ts'
+    )
+  );
+
+  expect(namespace.kind).toBe('namespace');
 });

--- a/__tests__/lib/infer/kind.js
+++ b/__tests__/lib/infer/kind.js
@@ -137,6 +137,22 @@ test('inferKind', function() {
   expect(abstractMethod.kind).toBe('function');
   expect(abstractMethod.abstract).toBe(true);
 
+  expect(inferKind(toComment('interface Foo { /** b */ b(v): void; }')).kind).toBe(
+    'function'
+  );
+
+  expect(inferKind(toComment('interface Foo { /** b */ b: string; }')).kind).toBe(
+    'member'
+  );
+
+  expect(inferKind(toComment('interface Foo { /** b */ b(v): void; }', 'test.ts')).kind).toBe(
+    'function'
+  );
+
+  expect(inferKind(toComment('interface Foo { /** b */ b: string; }', 'test.ts')).kind).toBe(
+    'member'
+  );
+
   expect(
     inferKind(
       toComment(function() {

--- a/__tests__/lib/infer/kind.js
+++ b/__tests__/lib/infer/kind.js
@@ -153,6 +153,14 @@ test('inferKind', function() {
     'member'
   );
 
+  expect(inferKind(toComment('/** */ enum Foo { A }', 'test.ts')).kind).toBe(
+    'enum'
+  );
+
+  expect(inferKind(toComment('enum Foo { /** */ A }', 'test.ts')).kind).toBe(
+    'member'
+  );
+
   expect(
     inferKind(
       toComment(function() {

--- a/__tests__/lib/infer/kind.js
+++ b/__tests__/lib/infer/kind.js
@@ -38,6 +38,10 @@ test('inferKind', function() {
     ).kind
   ).toBe('class');
 
+  const abstractClass = inferKind(toComment('/** */ abstract class C {}', 'test.ts'));
+  expect(abstractClass.kind).toBe('class');
+  expect(abstractClass.abstract).toBe(true);
+
   expect(
     inferKind(
       toComment(function() {
@@ -123,6 +127,10 @@ test('inferKind', function() {
   );
   expect(generatorMethod.kind).toBe('function');
   expect(generatorMethod.generator).toBe(true);
+
+  const abstractMethod = inferKind(toComment('abstract class C { /** */ abstract foo() {} }', 'test.ts'));
+  expect(abstractMethod.kind).toBe('function');
+  expect(abstractMethod.abstract).toBe(true);
 
   expect(
     inferKind(

--- a/__tests__/lib/infer/membership.js
+++ b/__tests__/lib/infer/membership.js
@@ -310,6 +310,22 @@ test('inferMembership - explicit', function() {
 
   expect(
     pick(
+      evaluate(`
+        /** @memberof bar */
+        abstract class Foo {
+          /** */
+          abstract baz();
+        }
+      `, 'test.ts')[1], // [0] is an description for class Foo
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'bar.Foo',
+    scope: 'instance'
+  });
+
+  expect(
+    pick(
       evaluate(function() {
         /** Test */
         module.exports = function() {};

--- a/__tests__/lib/infer/membership.js
+++ b/__tests__/lib/infer/membership.js
@@ -326,6 +326,38 @@ test('inferMembership - explicit', function() {
 
   expect(
     pick(
+      evaluate(`
+        /** @memberof bar */
+        interface Foo {
+          /** */
+          baz(): string;
+        }
+      `)[1], // [0] is an description for class Foo
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'bar.Foo',
+    scope: 'instance'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        /** @memberof bar */
+        interface Foo {
+          /** */
+          baz(): string;
+        }
+      `, 'test.ts')[1], // [0] is an description for class Foo
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'bar.Foo',
+    scope: 'instance'
+  });
+
+  expect(
+    pick(
       evaluate(function() {
         /** Test */
         module.exports = function() {};

--- a/__tests__/lib/infer/membership.js
+++ b/__tests__/lib/infer/membership.js
@@ -473,6 +473,21 @@ test('inferMembership - explicit', function() {
 
   expect(
     pick(
+      evaluate(`
+        enum Foo {
+          /** */
+          A
+        }
+      `, 'test.ts')[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo',
+    scope: 'static'
+  });
+
+  expect(
+    pick(
       evaluate(function() {
         /** Test */
         module.exports = function() {};

--- a/__tests__/lib/infer/membership.js
+++ b/__tests__/lib/infer/membership.js
@@ -144,6 +144,23 @@ test('inferMembership - explicit', function() {
   expect(
     pick(
       evaluate(function() {
+        Foo.bar = {
+          baz: {
+            /** Test */
+            test: 0
+          }
+        };
+      })[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo.bar.baz',
+    scope: 'static'
+  });
+
+  expect(
+    pick(
+      evaluate(function() {
         Foo.prototype = {
           /** Test */
           bar: 0
@@ -354,6 +371,104 @@ test('inferMembership - explicit', function() {
   ).toEqual({
     memberof: 'bar.Foo',
     scope: 'instance'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        interface Foo {
+          bar: {
+            /** */
+            baz: string;
+          }
+        }
+      `)[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo.bar',
+    scope: 'instance'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        interface Foo {
+          bar: {
+            /** */
+            baz: string;
+          }
+        }
+      `, 'test.ts')[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo.bar',
+    scope: 'instance'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        type Foo = {
+          /** */
+          bar: string;
+        }
+      `)[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo',
+    scope: 'static'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        type Foo = {
+          bar: {
+            /** */
+            baz: string;
+          }
+        }
+      `)[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo.bar',
+    scope: 'static'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        type Foo = {
+          /** */
+          bar: string;
+        }
+      `, 'test.ts')[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo',
+    scope: 'static'
+  });
+
+  expect(
+    pick(
+      evaluate(`
+        type Foo = {
+          bar: {
+            /** */
+            baz: string;
+          }
+        }
+      `, 'test.ts')[0],
+      ['memberof', 'scope']
+    )
+  ).toEqual({
+    memberof: 'Foo.bar',
+    scope: 'static'
   });
 
   expect(

--- a/__tests__/lib/infer/name.js
+++ b/__tests__/lib/infer/name.js
@@ -193,6 +193,12 @@ test('inferName', function() {
 
   expect(evaluate('/** Test */ export class Wizard {}').name).toBe('Wizard');
 
+  expect(evaluate('/** Test */ interface Wizard {}').name).toBe('Wizard');
+  expect(evaluate('/** Test */ interface Wizard {}', 'test.ts').name).toBe('Wizard');
+
+  expect(evaluate('/** Test */ enum Wizard {}', 'test.ts').name).toBe('Wizard');
+  expect(evaluate('enum Wizard { /** Test */ A }', 'test.ts').name).toBe('A');
+
   expect(
     evaluate(
       '/** Test */ export default class Warlock {}',

--- a/__tests__/lib/infer/params.js
+++ b/__tests__/lib/infer/params.js
@@ -245,4 +245,12 @@ test('inferParams (typescript)', function() {
   expect(
     evaluate(`/** Test */function f(...a: string) {};`, 'test.ts').params
   ).toMatchSnapshot();
+
+  expect(
+    evaluate(`/** Test */function f(a?: string) {};`).params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`/** Test */function f(a?: string) {};`, 'test.ts').params
+  ).toMatchSnapshot();
 });

--- a/__tests__/lib/infer/params.js
+++ b/__tests__/lib/infer/params.js
@@ -203,3 +203,46 @@ test('inferParams', function() {
     ).params
   ).toMatchSnapshot();
 });
+
+test('inferParams (typescript)', function() {
+  expect(
+    evaluate(`/** Test */function f(a: string) {};`, 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`/** Test */function f([a: string, b, {c}]) {};`, 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(
+      `
+    /** Test
+     * @param x
+    */
+    function f(x: number = 4) {}
+  `
+  , 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(
+      `
+    /** Test */
+    function f(opts: { x: string }) {}
+  ` , 'test.ts'
+    ).params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(
+      `
+    /** Test */
+    function f(opts: { [foo]: string }) {}
+  ` , 'test.ts'
+    ).params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`/** Test */function f(...a: string) {};`, 'test.ts').params
+  ).toMatchSnapshot();
+});

--- a/__tests__/lib/infer/params.js
+++ b/__tests__/lib/infer/params.js
@@ -253,4 +253,12 @@ test('inferParams (typescript)', function() {
   expect(
     evaluate(`/** Test */function f(a?: string) {};`, 'test.ts').params
   ).toMatchSnapshot();
+
+  expect(
+    evaluate(`/** Test */function f(a?: string);`, 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`abstract class Foo { /** */ abstract f(a?: string); }`, 'test.ts').params
+  ).toMatchSnapshot();
 });

--- a/__tests__/lib/infer/params.js
+++ b/__tests__/lib/infer/params.js
@@ -202,6 +202,18 @@ test('inferParams', function() {
   `
     ).params
   ).toMatchSnapshot();
+
+  expect(
+    evaluate(`interface Foo { /** b */ b(v: string): void; }`).params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`type Foo = { /** b */ b(v: string): void }`).params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`interface Foo { /** b */ b(...v: string): void; }`).params
+  ).toMatchSnapshot();
 });
 
 test('inferParams (typescript)', function() {
@@ -260,5 +272,17 @@ test('inferParams (typescript)', function() {
 
   expect(
     evaluate(`abstract class Foo { /** */ abstract f(a?: string); }`, 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`interface Foo { /** b */ b(v: string): void; }`, 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`type Foo = { /** b */ b(v: string): void }`, 'test.ts').params
+  ).toMatchSnapshot();
+
+  expect(
+    evaluate(`interface Foo { /** b */ b(...v: string): void; }`, 'test.ts').params
   ).toMatchSnapshot();
 });

--- a/__tests__/lib/infer/properties.js
+++ b/__tests__/lib/infer/properties.js
@@ -12,11 +12,11 @@ function toComment(fn, filename) {
   )[0];
 }
 
-function evaluate(code) {
-  return inferProperties(toComment(code));
+function evaluate(code, filename) {
+  return inferProperties(toComment(code, filename));
 }
 
-test('inferProperties', function() {
+test('inferProperties (flow)', function() {
   expect(evaluate('/** */type a = { b: 1 };').properties).toEqual([
     {
       lineNumber: 1,
@@ -43,8 +43,137 @@ test('inferProperties', function() {
     }
   ]);
 
+  expect(evaluate('/** */type a = { b: { c: 2 } };').properties).toEqual([
+    {
+      lineNumber: 1,
+      name: 'b',
+      title: 'property',
+      type: {
+        type: 'RecordType',
+        fields: [
+          {
+            key: 'c',
+            type: 'FieldType',
+            value: {
+              type: 'NumericLiteralType',
+              value: 2
+            }
+          }
+        ]
+      }
+    },
+    {
+      lineNumber: 1,
+      name: 'b.c',
+      title: 'property',
+      type: {
+        type: 'NumericLiteralType',
+        value: 2
+      }
+    }
+  ]);
+
   expect(
     evaluate('/** */interface a { b: 1, c: { d: 2 } };').properties
+  ).toEqual([
+    {
+      lineNumber: 1,
+      name: 'b',
+      title: 'property',
+      type: {
+        type: 'NumericLiteralType',
+        value: 1
+      }
+    },
+    {
+      lineNumber: 1,
+      name: 'c',
+      title: 'property',
+      type: {
+        fields: [
+          {
+            key: 'd',
+            type: 'FieldType',
+            value: {
+              type: 'NumericLiteralType',
+              value: 2
+            }
+          }
+        ],
+        type: 'RecordType'
+      }
+    },
+    {
+      lineNumber: 1,
+      name: 'c.d',
+      title: 'property',
+      type: {
+        type: 'NumericLiteralType',
+        value: 2
+      }
+    }
+  ]);
+});
+
+test('inferProperties (typescript)', function() {
+  expect(evaluate('/** */type a = { b: 1 };', 'test.ts').properties).toEqual([
+    {
+      lineNumber: 1,
+      name: 'b',
+      title: 'property',
+      type: {
+        type: 'NumericLiteralType',
+        value: 1
+      }
+    }
+  ]);
+
+  expect(
+    evaluate('/** @property {number} b */ type a = { b: 1 };', 'test.ts').properties
+  ).toEqual([
+    {
+      lineNumber: 0,
+      name: 'b',
+      title: 'property',
+      type: {
+        name: 'number',
+        type: 'NameExpression'
+      }
+    }
+  ]);
+
+  expect(evaluate('/** */type a = { b: { c: 2 } };', 'test.ts').properties).toEqual([
+    {
+      lineNumber: 1,
+      name: 'b',
+      title: 'property',
+      type: {
+        type: 'RecordType',
+        fields: [
+          {
+            key: 'c',
+            type: 'FieldType',
+            value: {
+              type: 'NumericLiteralType',
+              value: 2
+            }
+          }
+        ]
+      }
+    },
+    {
+      lineNumber: 1,
+      name: 'b.c',
+      title: 'property',
+      type: {
+        type: 'NumericLiteralType',
+        value: 2
+      }
+    }
+  ]);
+
+  expect(
+    evaluate('/** */interface a { b: 1, c: { d: 2 } };', 'test.ts').properties
   ).toEqual([
     {
       lineNumber: 1,

--- a/__tests__/lib/infer/properties.js
+++ b/__tests__/lib/infer/properties.js
@@ -72,47 +72,6 @@ test('inferProperties (flow)', function() {
       }
     }
   ]);
-
-  expect(
-    evaluate('/** */interface a { b: 1, c: { d: 2 } };').properties
-  ).toEqual([
-    {
-      lineNumber: 1,
-      name: 'b',
-      title: 'property',
-      type: {
-        type: 'NumericLiteralType',
-        value: 1
-      }
-    },
-    {
-      lineNumber: 1,
-      name: 'c',
-      title: 'property',
-      type: {
-        fields: [
-          {
-            key: 'd',
-            type: 'FieldType',
-            value: {
-              type: 'NumericLiteralType',
-              value: 2
-            }
-          }
-        ],
-        type: 'RecordType'
-      }
-    },
-    {
-      lineNumber: 1,
-      name: 'c.d',
-      title: 'property',
-      type: {
-        type: 'NumericLiteralType',
-        value: 2
-      }
-    }
-  ]);
 });
 
 test('inferProperties (typescript)', function() {
@@ -164,47 +123,6 @@ test('inferProperties (typescript)', function() {
     {
       lineNumber: 1,
       name: 'b.c',
-      title: 'property',
-      type: {
-        type: 'NumericLiteralType',
-        value: 2
-      }
-    }
-  ]);
-
-  expect(
-    evaluate('/** */interface a { b: 1, c: { d: 2 } };', 'test.ts').properties
-  ).toEqual([
-    {
-      lineNumber: 1,
-      name: 'b',
-      title: 'property',
-      type: {
-        type: 'NumericLiteralType',
-        value: 1
-      }
-    },
-    {
-      lineNumber: 1,
-      name: 'c',
-      title: 'property',
-      type: {
-        fields: [
-          {
-            key: 'd',
-            type: 'FieldType',
-            value: {
-              type: 'NumericLiteralType',
-              value: 2
-            }
-          }
-        ],
-        type: 'RecordType'
-      }
-    },
-    {
-      lineNumber: 1,
-      name: 'c.d',
       title: 'property',
       type: {
         type: 'NumericLiteralType',

--- a/__tests__/lib/infer/properties.js
+++ b/__tests__/lib/infer/properties.js
@@ -61,15 +61,6 @@ test('inferProperties (flow)', function() {
           }
         ]
       }
-    },
-    {
-      lineNumber: 1,
-      name: 'b.c',
-      title: 'property',
-      type: {
-        type: 'NumericLiteralType',
-        value: 2
-      }
     }
   ]);
 });
@@ -118,15 +109,6 @@ test('inferProperties (typescript)', function() {
             }
           }
         ]
-      }
-    },
-    {
-      lineNumber: 1,
-      name: 'b.c',
-      title: 'property',
-      type: {
-        type: 'NumericLiteralType',
-        value: 2
       }
     }
   ]);

--- a/__tests__/lib/infer/return.js
+++ b/__tests__/lib/infer/return.js
@@ -12,11 +12,11 @@ function toComment(fn, filename) {
   )[0];
 }
 
-function evaluate(code) {
-  return inferReturn(toComment(code));
+function evaluate(code, filename) {
+  return inferReturn(toComment(code, filename));
 }
 
-test('inferReturn', function() {
+test('inferReturn (flow)', function() {
   expect(evaluate('/** */function a(): number {}').returns).toEqual([
     {
       title: 'returns',
@@ -60,6 +60,55 @@ test('inferReturn', function() {
       type: {
         name: 'Bar',
         type: 'NameExpression'
+      }
+    }
+  ]);
+});
+
+test('inferReturn (typescript)', function() {
+  expect(evaluate('/** */function a(): number {}', 'test.ts').returns).toEqual([
+    {
+      title: 'returns',
+      type: {
+        name: 'number',
+        type: 'NameExpression'
+      }
+    }
+  ]);
+  expect(evaluate('/** */var a = function(): number {}', 'test.ts').returns).toEqual([
+    {
+      title: 'returns',
+      type: {
+        name: 'number',
+        type: 'NameExpression'
+      }
+    }
+  ]);
+  expect(
+    evaluate('/** @returns {string} */function a(): number {}', 'test.ts').returns[0].type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+  const generatorFn = evaluate(
+    '/** */function *a(): IterableIterator<Foo> {}',
+    'test.ts'
+  );
+  expect(generatorFn.generator).toBe(true);
+  expect(generatorFn.yields).toEqual([
+    {
+      title: 'yields',
+      type: {
+        name: 'Foo',
+        type: 'NameExpression'
+      }
+    }
+  ]);
+  expect(generatorFn.returns).toEqual([
+    {
+      title: 'returns',
+      type: {
+        type: 'VoidLiteral'
       }
     }
   ]);

--- a/__tests__/lib/infer/return.js
+++ b/__tests__/lib/infer/return.js
@@ -63,6 +63,20 @@ test('inferReturn (flow)', function() {
       }
     }
   ]);
+
+  expect(
+    evaluate('interface Foo { /** */ bar(): string; }').returns[0].type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('type Foo = { /** */ bar(): string; }').returns[0].type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
 });
 
 test('inferReturn (typescript)', function() {
@@ -132,4 +146,18 @@ test('inferReturn (typescript)', function() {
       }
     }
   ]);
+
+  expect(
+    evaluate('interface Foo { /** */ bar(): string; }', 'test.ts').returns[0].type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('type Foo = { /** */ bar(): string; }', 'test.ts').returns[0].type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
 });

--- a/__tests__/lib/infer/return.js
+++ b/__tests__/lib/infer/return.js
@@ -112,4 +112,24 @@ test('inferReturn (typescript)', function() {
       }
     }
   ]);
+
+  expect(evaluate('/** */function a(): number;', 'test.ts').returns).toEqual([
+    {
+      title: 'returns',
+      type: {
+        name: 'number',
+        type: 'NameExpression'
+      }
+    }
+  ]);
+
+  expect(evaluate('abstract class Test { /** */abstract a(): number; }', 'test.ts').returns).toEqual([
+    {
+      title: 'returns',
+      type: {
+        name: 'number',
+        type: 'NameExpression'
+      }
+    }
+  ]);
 });

--- a/__tests__/lib/infer/type.js
+++ b/__tests__/lib/infer/type.js
@@ -16,7 +16,7 @@ function evaluate(code, filename) {
   return inferType(inferKind(toComment(code, filename)));
 }
 
-test('inferType', function() {
+test('inferType (flow)', function() {
   expect(evaluate('/** @typedef {T} V */').type).toEqual({
     name: 'T',
     type: 'NameExpression'
@@ -112,16 +112,6 @@ test('inferType', function() {
     type: 'NameExpression'
   });
 
-  expect(evaluate('class Foo { /** */ get b(): string { } }', 'test.ts').type).toEqual({
-    name: 'string',
-    type: 'NameExpression'
-  });
-
-  expect(evaluate('class Foo { /** */ set b(s: string) { } }', 'test.ts').type).toEqual({
-    name: 'string',
-    type: 'NameExpression'
-  });
-
   expect(evaluate('/** */' + 'const x = 42;').type).toEqual({
     name: 'number',
     type: 'NameExpression'
@@ -133,6 +123,118 @@ test('inferType', function() {
   });
 
   expect(evaluate('/** */' + 'const x = true;').type).toEqual({
+    name: 'boolean',
+    type: 'NameExpression'
+  });
+});
+
+test('inferType (typescript)', function() {
+  expect(evaluate('/** @typedef {T} V */', 'test.ts').type).toEqual({
+    name: 'T',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** */' + 'type V = T', 'test.ts').type).toEqual({
+    name: 'T',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** @typedef {Array<T>} V */', 'test.ts').type).toEqual({
+    applications: [
+      {
+        name: 'T',
+        type: 'NameExpression'
+      }
+    ],
+    expression: {
+      name: 'Array',
+      type: 'NameExpression'
+    },
+    type: 'TypeApplication'
+  });
+
+  expect(evaluate('/** */' + "type V = {a:number,'b':string}", 'test.ts').type).toEqual({
+    fields: [
+      {
+        key: 'a',
+        type: 'FieldType',
+        value: {
+          name: 'number',
+          type: 'NameExpression'
+        }
+      },
+      {
+        key: 'b',
+        type: 'FieldType',
+        value: {
+          name: 'string',
+          type: 'NameExpression'
+        }
+      }
+    ],
+    type: 'RecordType'
+  });
+
+  expect(evaluate('/** */' + 'type V = Array<T>', 'test.ts').type).toEqual({
+    applications: [
+      {
+        name: 'T',
+        type: 'NameExpression'
+      }
+    ],
+    expression: {
+      name: 'Array',
+      type: 'NameExpression'
+    },
+    type: 'TypeApplication'
+  });
+
+  expect(evaluate('/** */' + 'var x: number', 'test.ts').type).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** */' + 'let x: number', 'test.ts').type).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** */' + 'const x: number = 42;', 'test.ts').type).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('let x,' + '/** */' + 'y: number', 'test.ts').type).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('class C {' + '/** */' + 'x: number;' + '}', 'test.ts').type).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('class Foo { /** */ get b(): string { } }', 'test.ts').type).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('class Foo { /** */ set b(s: string) { } }', 'test.ts').type).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** */' + 'const x = 42;', 'test.ts').type).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** */' + 'const x = "abc";', 'test.ts').type).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('/** */' + 'const x = true;', 'test.ts').type).toEqual({
     name: 'boolean',
     type: 'NameExpression'
   });

--- a/__tests__/lib/infer/type.js
+++ b/__tests__/lib/infer/type.js
@@ -224,6 +224,16 @@ test('inferType (typescript)', function() {
     type: 'NameExpression'
   });
 
+  expect(evaluate('abstract class Foo { /** */ abstract get b(): string; }', 'test.ts').type).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(evaluate('abstract class Foo { /** */ abstract set b(s: string); }', 'test.ts').type).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
   expect(evaluate('/** */' + 'const x = 42;', 'test.ts').type).toEqual({
     name: 'number',
     type: 'NameExpression'

--- a/__tests__/lib/infer/type.js
+++ b/__tests__/lib/infer/type.js
@@ -276,4 +276,29 @@ test('inferType (typescript)', function() {
     name: 'string',
     type: 'NameExpression'
   });
+
+  expect(
+    evaluate('enum Foo { /** */ A }', 'test.ts').type
+  ).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('enum Foo { /** */ A = 2 }', 'test.ts').type
+  ).toEqual({
+    name: 'number',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('enum Foo { /** */ A = "test" }', 'test.ts').type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('enum Foo { /** */ A = foo }', 'test.ts').type
+  ).toBe(undefined);
 });

--- a/__tests__/lib/infer/type.js
+++ b/__tests__/lib/infer/type.js
@@ -126,6 +126,20 @@ test('inferType (flow)', function() {
     name: 'boolean',
     type: 'NameExpression'
   });
+
+  expect(
+    evaluate('interface Foo { /** */ bar: string; }').type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('type Foo = { /** */ bar: string; }').type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
 });
 
 test('inferType (typescript)', function() {
@@ -246,6 +260,20 @@ test('inferType (typescript)', function() {
 
   expect(evaluate('/** */' + 'const x = true;', 'test.ts').type).toEqual({
     name: 'boolean',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('interface Foo { /** */ bar: string; }', 'test.ts').type
+  ).toEqual({
+    name: 'string',
+    type: 'NameExpression'
+  });
+
+  expect(
+    evaluate('type Foo = { /** */ bar: string; }', 'test.ts').type
+  ).toEqual({
+    name: 'string',
     type: 'NameExpression'
   });
 });

--- a/__tests__/lib/parse.js
+++ b/__tests__/lib/parse.js
@@ -494,7 +494,13 @@ test('parse - @ignore', function() {
   ).toBe(true);
 });
 
-test('parse - @implements', function() {});
+test('parse - @implements', function() {
+  expect(
+    evaluate(function() {
+      /** @implements {Foo} */
+    })[0].implements[0].name
+  ).toEqual('Foo');
+});
 
 test('parse - @inheritdoc', function() {});
 

--- a/__tests__/lib/parse.js
+++ b/__tests__/lib/parse.js
@@ -302,7 +302,22 @@ test('parse - description', function() {
 
 test('parse - @emits', function() {});
 
-test('parse - @enum', function() {});
+test('parse - @enum', function() {
+  expect(
+    pick(
+      evaluate(function() {
+        /** @enum {string} */
+      })[0],
+      ['kind', 'type']
+    )
+  ).toEqual({
+    kind: 'enum',
+    type: {
+      type: 'NameExpression',
+      name: 'string'
+    }
+  });
+});
 
 test('parse - @event', function() {
   expect(
@@ -524,8 +539,8 @@ test('parse - @interface', function() {
   expect(
     evaluate(function() {
       /** @interface */
-    })[0].interface
-  ).toEqual(true);
+    })[0].kind
+  ).toEqual('interface');
 
   expect(
     evaluate(function() {

--- a/__tests__/lib/parsers/parse_to_ast.js
+++ b/__tests__/lib/parsers/parse_to_ast.js
@@ -18,6 +18,6 @@ describe('flow comments', () => {
   });
 
   test('valid js', () => {
-    expect(() => parseToAst(src)).not.toThrowError();
+    expect(() => parseToAst(src, 'test.js')).not.toThrowError();
   });
 });

--- a/__tests__/lib/ts_doctrine.js
+++ b/__tests__/lib/ts_doctrine.js
@@ -1,0 +1,407 @@
+const tsDoctrine = require('../../src/ts_doctrine.js');
+const parse = require('../../src/parsers/javascript');
+const TSTYPE_TYPES = require('@babel/types').TSTYPE_TYPES;
+
+function toComment(fn, filename) {
+  return parse(
+    {
+      file: filename || 'test.ts',
+      source: fn instanceof Function ? '(' + fn.toString() + ')' : fn
+    },
+    {}
+  )[0];
+}
+
+test('tsDoctrine', function() {
+  const types = TSTYPE_TYPES.slice();
+
+  function toDoctrineType(flowType) {
+    const annotation = toComment(
+      '/** add */function add(a: ' + flowType + ' ) { }'
+    ).context.ast.node.params[0].typeAnnotation.typeAnnotation;
+    if (types.indexOf(annotation.type) !== -1) {
+      types.splice(types.indexOf(annotation.type), 1);
+    }
+    return tsDoctrine(annotation);
+  }
+
+  expect(toDoctrineType('number')).toEqual({
+    type: 'NameExpression',
+    name: 'number'
+  });
+
+  expect(toDoctrineType('string')).toEqual({
+    type: 'NameExpression',
+    name: 'string'
+  });
+
+  expect(toDoctrineType('boolean')).toEqual({
+    type: 'NameExpression',
+    name: 'boolean'
+  });
+
+  expect(toDoctrineType('symbol')).toEqual({
+    type: 'NameExpression',
+    name: 'symbol'
+  });
+
+  expect(toDoctrineType('object')).toEqual({
+    type: 'NameExpression',
+    name: 'object'
+  });
+
+  expect(toDoctrineType('any')).toEqual({
+    type: 'AllLiteral'
+  });
+
+  expect(toDoctrineType('this')).toEqual({
+    type: 'NameExpression',
+    name: 'this'
+  });
+
+  expect(toDoctrineType('never')).toEqual({
+    type: 'NameExpression',
+    name: 'never'
+  });
+
+  expect(toDoctrineType('(y:Foo) => Bar')).toEqual({
+    type: 'FunctionType',
+    params: [
+      {
+        type: 'ParameterType',
+        name: 'y',
+        expression: {
+          type: 'NameExpression',
+          name: 'Foo'
+        }
+      }
+    ],
+    result: {
+      type: 'NameExpression',
+      name: 'Bar'
+    }
+  });
+
+  expect(toDoctrineType('new (y:Foo) => Bar')).toEqual({
+    type: 'FunctionType',
+    params: [
+      {
+        type: 'ParameterType',
+        name: 'y',
+        expression: {
+          type: 'NameExpression',
+          name: 'Foo'
+        }
+      }
+    ],
+    result: {
+      type: 'NameExpression',
+      name: 'Bar'
+    }
+  });
+
+  expect(toDoctrineType('(...y: Foo) => Bar')).toEqual({
+    type: 'FunctionType',
+    params: [
+      {
+        type: 'RestType',
+        expression: {
+          type: 'ParameterType',
+          name: 'y',
+          expression: {
+            type: 'NameExpression',
+            name: 'Foo'
+          }
+        }
+      }
+    ],
+    result: {
+      type: 'NameExpression',
+      name: 'Bar'
+    }
+  });
+
+  expect(toDoctrineType('number | string')).toEqual({
+    type: 'UnionType',
+    elements: [
+      {
+        type: 'NameExpression',
+        name: 'number'
+      },
+      {
+        type: 'NameExpression',
+        name: 'string'
+      }
+    ]
+  });
+
+  expect(toDoctrineType('(number | string)')).toEqual({
+    type: 'UnionType',
+    elements: [
+      {
+        type: 'NameExpression',
+        name: 'number'
+      },
+      {
+        type: 'NameExpression',
+        name: 'string'
+      }
+    ]
+  });
+
+  expect(toDoctrineType('Object')).toEqual({
+    type: 'NameExpression',
+    name: 'Object'
+  });
+
+  expect(toDoctrineType('namedType.propertyOfType')).toEqual({
+    type: 'NameExpression',
+    name: 'namedType.propertyOfType'
+  });
+
+  expect(toDoctrineType('Array<namedType.propertyOfType>')).toEqual({
+    applications: [
+      {
+        type: 'NameExpression',
+        name: 'namedType.propertyOfType'
+      }
+    ],
+    expression: {
+      name: 'Array',
+      type: 'NameExpression'
+    },
+    type: 'TypeApplication'
+  });
+
+  expect(toDoctrineType('Array<namedType.propertyOfType<boolean>>')).toEqual({
+    applications: [
+      {
+        applications: [
+          {
+            name: 'boolean',
+            type: 'NameExpression'
+          }
+        ],
+        expression: {
+          type: 'NameExpression',
+          name: 'namedType.propertyOfType'
+        },
+        type: 'TypeApplication'
+      }
+    ],
+    expression: {
+      name: 'Array',
+      type: 'NameExpression'
+    },
+    type: 'TypeApplication'
+  });
+
+  expect(toDoctrineType('{ a: foo.bar }')).toEqual({
+    fields: [
+      {
+        key: 'a',
+        type: 'FieldType',
+        value: {
+          name: 'foo.bar',
+          type: 'NameExpression'
+        }
+      }
+    ],
+    type: 'RecordType'
+  });
+
+  expect(toDoctrineType('{ a: { b: foo.bar } }')).toEqual({
+    fields: [
+      {
+        key: 'a',
+        type: 'FieldType',
+        value: {
+          type: 'RecordType',
+          fields: [
+            {
+              key: 'b',
+              type: 'FieldType',
+              value: {
+                name: 'foo.bar',
+                type: 'NameExpression'
+              }
+            }
+          ]
+        }
+      }
+    ],
+    type: 'RecordType'
+  });
+
+  expect(toDoctrineType('{ a: 1 }')).toEqual({
+    type: 'RecordType',
+    fields: [
+      {
+        type: 'FieldType',
+        key: 'a',
+        value: {
+          type: 'NumericLiteralType',
+          value: 1
+        }
+      }
+    ]
+  });
+
+  expect(toDoctrineType('{ a?: string }')).toEqual({
+    type: 'RecordType',
+    fields: [
+      {
+        type: 'FieldType',
+        key: 'a',
+        value: {
+          type: 'OptionalType',
+          expression: {
+            name: 'string',
+            type: 'NameExpression'
+          }
+        }
+      }
+    ]
+  });
+
+  expect(toDoctrineType('unknown')).toEqual({
+    type: 'AllLiteral'
+  });
+
+  expect(toDoctrineType('Array')).toEqual({
+    type: 'NameExpression',
+    name: 'Array'
+  });
+
+  expect(toDoctrineType('Array<number>')).toEqual({
+    type: 'TypeApplication',
+    expression: {
+      type: 'NameExpression',
+      name: 'Array'
+    },
+    applications: [
+      {
+        type: 'NameExpression',
+        name: 'number'
+      }
+    ]
+  });
+
+  expect(toDoctrineType('number[]')).toEqual({
+    type: 'TypeApplication',
+    expression: {
+      type: 'NameExpression',
+      name: 'Array'
+    },
+    applications: [
+      {
+        type: 'NameExpression',
+        name: 'number'
+      }
+    ]
+  });
+
+  expect(toDoctrineType('[]')).toEqual({
+    type: 'ArrayType',
+    elements: []
+  });
+
+  expect(toDoctrineType('[number]')).toEqual({
+    type: 'ArrayType',
+    elements: [
+      {
+        type: 'NameExpression',
+        name: 'number'
+      }
+    ]
+  });
+
+  expect(toDoctrineType('[string, boolean]')).toEqual({
+    type: 'ArrayType',
+    elements: [
+      {
+        type: 'NameExpression',
+        name: 'string'
+      },
+      {
+        type: 'NameExpression',
+        name: 'boolean'
+      }
+    ]
+  });
+
+  expect(toDoctrineType('[string, ...boolean]')).toEqual({
+    type: 'ArrayType',
+    elements: [
+      {
+        type: 'NameExpression',
+        name: 'string'
+      },
+      {
+        type: 'RestType',
+        expression: {
+          type: 'NameExpression',
+          name: 'boolean'
+        }
+      }
+    ]
+  });
+
+  expect(toDoctrineType('(y:any) => any')).toEqual({
+    type: 'FunctionType',
+    params: [
+      {
+        expression: { type: 'AllLiteral' },
+        name: 'y',
+        type: 'ParameterType'
+      }
+    ],
+    result: { type: 'AllLiteral' }
+  });
+
+  expect(toDoctrineType('undefined')).toEqual({
+    type: 'UndefinedLiteral'
+  });
+
+  expect(toDoctrineType('"value"')).toEqual({
+    type: 'StringLiteralType',
+    value: 'value'
+  });
+
+  expect(toDoctrineType('1')).toEqual({
+    type: 'NumericLiteralType',
+    value: 1
+  });
+
+  expect(toDoctrineType('true')).toEqual({
+    type: 'BooleanLiteralType',
+    value: true
+  });
+
+  expect(toDoctrineType('false')).toEqual({
+    type: 'BooleanLiteralType',
+    value: false
+  });
+
+  expect(toDoctrineType('null')).toEqual({
+    type: 'NullLiteral'
+  });
+
+  expect(toDoctrineType('void')).toEqual({
+    type: 'VoidLiteral'
+  });
+
+  expect(types).toEqual([
+    'TSTypePredicate',
+    'TSTypeQuery',
+    'TSOptionalType', // handled - not top-level.
+    'TSRestType', // handled - not top-level.
+    'TSIntersectionType', // no equivalent in doctrine...
+    'TSConditionalType',
+    'TSInferType',
+    'TSTypeOperator',
+    'TSIndexedAccessType',
+    'TSMappedType',
+    'TSExpressionWithTypeArguments'
+  ]);
+});

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -101,6 +101,7 @@ type Comment = {
   access?: Access,
   readonly?: boolean,
   abstract?: boolean,
+  generator?: boolean,
   alias?: string,
 
   copyright?: string,

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -100,6 +100,7 @@ type Comment = {
   scope?: Scope,
   access?: Access,
   readonly?: boolean,
+  abstract?: boolean,
   alias?: string,
 
   copyright?: string,

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -78,6 +78,7 @@ type Comment = {
 
   augments: Array<CommentTag>,
   examples: Array<CommentExample>,
+  implements: Array<CommentTag>,
   params: Array<CommentTag>,
   properties: Array<CommentTag>,
   returns: Array<CommentTag>,

--- a/declarations/comment.js
+++ b/declarations/comment.js
@@ -68,7 +68,8 @@ type CommentTag = {
   default?: any,
   lineNumber?: number,
   type?: DoctrineType,
-  properties?: Array<CommentTag>
+  properties?: Array<CommentTag>,
+  readonly?: boolean
 };
 
 type Comment = {
@@ -98,6 +99,7 @@ type Comment = {
   memberof?: string,
   scope?: Scope,
   access?: Access,
+  readonly?: boolean,
   alias?: string,
 
   copyright?: string,

--- a/src/extractors/exported.js
+++ b/src/extractors/exported.js
@@ -182,7 +182,7 @@ function getCachedData(dataCache, filePath) {
   let value = dataCache.get(path);
   if (!value) {
     const input = fs.readFileSync(path, 'utf-8');
-    const ast = parseToAst(input);
+    const ast = parseToAst(input, filePath);
     value = {
       data: {
         file: path,

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const hierarchy = require('./hierarchy');
 const inferName = require('./infer/name');
 const inferKind = require('./infer/kind');
 const inferAugments = require('./infer/augments');
+const inferImplements = require('./infer/implements');
 const inferParams = require('./infer/params');
 const inferProperties = require('./infer/properties');
 const inferMembership = require('./infer/membership');
@@ -89,6 +90,7 @@ function buildInternal(inputsAndConfig) {
     inferName,
     inferAccess(config.inferPrivate),
     inferAugments,
+    inferImplements,
     inferKind,
     nest,
     inferParams,

--- a/src/infer/access.js
+++ b/src/infer/access.js
@@ -1,5 +1,3 @@
-const t = require('@babel/types');
-
 /**
  * Given a string with a pattern that might infer access level, like `^_`,
  * create an inference method.

--- a/src/infer/access.js
+++ b/src/infer/access.js
@@ -1,3 +1,5 @@
+const t = require('@babel/types');
+
 /**
  * Given a string with a pattern that might infer access level, like `^_`,
  * create an inference method.
@@ -17,6 +19,12 @@ function inferAccessWithPattern(pattern) {
    * @returns {Object} comment with access inferred
    */
   return function inferAccess(comment) {
+    // Support typescript access modifiers
+    const ast = comment.context.ast;
+    if (ast && ast.isClassMethod() && ast.node.accessibility) {
+      comment.access = ast.node.accessibility;
+    }
+
     // This needs to run after inferName beacuse we infer the access based on
     // the name.
     if (

--- a/src/infer/access.js
+++ b/src/infer/access.js
@@ -12,7 +12,7 @@ function inferAccessWithPattern(pattern) {
   const re = pattern && new RegExp(pattern);
 
   /**
-   * Infers access (only private atm) from the name.
+   * Infers access from TypeScript annotations, and from the name (only private atm).
    *
    * @name inferAccess
    * @param {Object} comment parsed comment
@@ -23,6 +23,10 @@ function inferAccessWithPattern(pattern) {
     const ast = comment.context.ast;
     if (ast && ast.isClassMethod() && ast.node.accessibility) {
       comment.access = ast.node.accessibility;
+    }
+
+    if (ast && ast.node.readonly) {
+      comment.readonly = true;
     }
 
     // This needs to run after inferName beacuse we infer the access based on

--- a/src/infer/access.js
+++ b/src/infer/access.js
@@ -19,7 +19,7 @@ function inferAccessWithPattern(pattern) {
   return function inferAccess(comment) {
     // Support typescript access modifiers
     const ast = comment.context.ast;
-    if (ast && ast.isClassMethod() && ast.node.accessibility) {
+    if (ast && ast.node.accessibility) {
       comment.access = ast.node.accessibility;
     }
 

--- a/src/infer/augments.js
+++ b/src/infer/augments.js
@@ -31,7 +31,7 @@ function inferAugments(comment) {
         name: generate(path.node.superClass).code
       });
     }
-  } else if (path.isInterfaceDeclaration()) {
+  } else if (path.isInterfaceDeclaration() || path.isTSInterfaceDeclaration()) {
     /*
      * extends is an array of interface identifiers or
      * qualified type identifiers, so we generate code

--- a/src/infer/augments.js
+++ b/src/infer/augments.js
@@ -31,7 +31,7 @@ function inferAugments(comment) {
         name: generate(path.node.superClass).code
       });
     }
-  } else if (path.isInterfaceDeclaration() || path.isTSInterfaceDeclaration()) {
+  } else if ((path.isInterfaceDeclaration() || path.isTSInterfaceDeclaration()) && path.node.extends) {
     /*
      * extends is an array of interface identifiers or
      * qualified type identifiers, so we generate code

--- a/src/infer/finders.js
+++ b/src/infer/finders.js
@@ -26,7 +26,7 @@ function findTarget(path) {
   } else if (t.isExpressionStatement(path)) {
     // foo.x = TARGET
     path = path.get('expression').get('right');
-  } else if (t.isObjectProperty(path)) {
+  } else if (t.isObjectProperty(path) || t.isObjectTypeProperty(path)) {
     // var foo = { x: TARGET }; object property
     path = path.get('value');
   } else if (t.isClassProperty(path) && path.get('value').node) {

--- a/src/infer/implements.js
+++ b/src/infer/implements.js
@@ -1,0 +1,38 @@
+const generate = require('@babel/generator').default;
+const findTarget = require('./finders').findTarget;
+
+/**
+ * Infers an `augments` tag from an ES6 class declaration
+ *
+ * @param {Object} comment parsed comment
+ * @returns {Object} comment with kind inferred
+ */
+function inferImplements(comment) {
+  if (comment.implements.length) {
+    return comment;
+  }
+
+  const path = findTarget(comment.context.ast);
+  if (!path) {
+    return comment;
+  }
+
+  if (path.isClass() && path.node.implements) {
+    /*
+     * A interface can be a single name, like React,
+     * or a MemberExpression like React.Component,
+     * so we generate code from the AST rather than assuming
+     * we can access a name like `path.node.implements.name`
+     */
+    path.node.implements.forEach(impl => {
+      comment.implements.push({
+        title: 'implements',
+        name: generate(impl).code
+      });  
+    });
+  }
+
+  return comment;
+}
+
+module.exports = inferImplements;

--- a/src/infer/kind.js
+++ b/src/infer/kind.js
@@ -18,6 +18,9 @@ function inferKind(comment) {
 
     if (t.isClassDeclaration(node)) {
       comment.kind = 'class';
+      if (node.abstract) {
+        comment.abstract = true;
+      }
     } else if (t.isFunction(node)) {
       if (node.kind === 'get' || node.kind === 'set') {
         comment.kind = 'member';
@@ -30,6 +33,9 @@ function inferKind(comment) {
         }
         if (node.generator) {
           comment.generator = true;
+        }
+        if (node.abstract) {
+          comment.abstract = true;
         }
       }
     } else if (t.isTypeAlias(node)) {

--- a/src/infer/kind.js
+++ b/src/infer/kind.js
@@ -21,7 +21,13 @@ function inferKind(comment) {
       if (node.abstract) {
         comment.abstract = true;
       }
-    } else if (t.isFunction(node) || t.isTSDeclareMethod(node) || t.isTSDeclareFunction(node)) {
+    } else if (
+      t.isFunction(node) || 
+      t.isTSDeclareMethod(node) || 
+      t.isTSDeclareFunction(node) || 
+      t.isFunctionTypeAnnotation(node) || 
+      t.isTSMethodSignature(node)
+    ) {
       if (node.kind === 'get' || node.kind === 'set') {
         comment.kind = 'member';
       } else if (node.id && node.id.name && !!/^[A-Z]/.exec(node.id.name)) {
@@ -59,13 +65,19 @@ function inferKind(comment) {
     } else if (t.isExpressionStatement(node)) {
       // module.exports = function() {}
       findKind(node.expression.right);
-    } else if (t.isClassProperty(node)) {
+    } else if (t.isClassProperty(node) || t.isTSPropertySignature(node)) {
       comment.kind = 'member';
     } else if (t.isProperty(node)) {
       // { foo: function() {} }
       findKind(node.value);
     } else if (t.isTSModuleDeclaration(node)) {
       comment.kind = 'namespace';
+    } else if (t.isObjectTypeProperty(node)) {
+      if (t.isFunctionTypeAnnotation(node.value)) {
+        findKind(node.value);
+      } else {
+        comment.kind = 'member';
+      }
     }
   }
 

--- a/src/infer/kind.js
+++ b/src/infer/kind.js
@@ -38,9 +38,9 @@ function inferKind(comment) {
           comment.abstract = true;
         }
       }
-    } else if (t.isTypeAlias(node)) {
+    } else if (t.isTypeAlias(node) || t.isTSTypeAliasDeclaration(node)) {
       comment.kind = 'typedef';
-    } else if (t.isInterfaceDeclaration(node)) {
+    } else if (t.isInterfaceDeclaration(node) || t.isTSInterfaceDeclaration(node)) {
       comment.kind = 'interface';
     } else if (t.isVariableDeclaration(node)) {
       if (node.kind === 'const') {
@@ -64,6 +64,8 @@ function inferKind(comment) {
     } else if (t.isProperty(node)) {
       // { foo: function() {} }
       findKind(node.value);
+    } else if (t.isTSModuleDeclaration(node)) {
+      comment.kind = 'namespace';
     }
   }
 

--- a/src/infer/kind.js
+++ b/src/infer/kind.js
@@ -65,7 +65,7 @@ function inferKind(comment) {
     } else if (t.isExpressionStatement(node)) {
       // module.exports = function() {}
       findKind(node.expression.right);
-    } else if (t.isClassProperty(node) || t.isTSPropertySignature(node)) {
+    } else if (t.isClassProperty(node) || t.isTSPropertySignature(node) || t.isTSEnumMember(node)) {
       comment.kind = 'member';
     } else if (t.isProperty(node)) {
       // { foo: function() {} }
@@ -78,6 +78,8 @@ function inferKind(comment) {
       } else {
         comment.kind = 'member';
       }
+    } else if (t.isTSEnumDeclaration(node)) {
+      comment.kind = 'enum';
     }
   }
 

--- a/src/infer/kind.js
+++ b/src/infer/kind.js
@@ -21,7 +21,7 @@ function inferKind(comment) {
       if (node.abstract) {
         comment.abstract = true;
       }
-    } else if (t.isFunction(node)) {
+    } else if (t.isFunction(node) || t.isTSDeclareMethod(node) || t.isTSDeclareFunction(node)) {
       if (node.kind === 'get' || node.kind === 'set') {
         comment.kind = 'member';
       } else if (node.id && node.id.name && !!/^[A-Z]/.exec(node.id.name)) {

--- a/src/infer/membership.js
+++ b/src/infer/membership.js
@@ -456,6 +456,17 @@ module.exports = function() {
       }
     }
 
+    // TypeScript enums
+    // enum Foo { A }
+    if (path.isTSEnumMember()) {
+      const enumPath = path.parentPath;
+      return inferMembershipFromIdentifiers(
+        comment,
+        [enumPath.node.id.name],
+        'static'
+      );
+    }
+
     // var function Foo() {
     //   function bar() {}
     //   return { bar: bar };

--- a/src/infer/membership.js
+++ b/src/infer/membership.js
@@ -341,7 +341,7 @@ module.exports = function() {
     // class Foo { prop: T }
     // var Foo = class { prop: T }
     if (
-      (path.isClassMethod() || path.isClassProperty()) &&
+      (path.isClassMethod() || path.isClassProperty() || path.isTSDeclareMethod()) &&
       path.parentPath.isClassBody() &&
       path.parentPath.parentPath.isClass()
     ) {

--- a/src/infer/membership.js
+++ b/src/infer/membership.js
@@ -359,7 +359,7 @@ module.exports = function() {
       }
 
       const declarationNode = path.parentPath.parentPath.node;
-      if (!declarationNode.id) {
+      if (!declarationNode.id && !declarationNode.key) {
         // export default function () {}
         // export default class {}
         // Use module name instead.
@@ -374,6 +374,20 @@ module.exports = function() {
         comment,
         inferClassMembership(path.parentPath.parentPath),
         scope
+      );
+    }
+
+    // interface Foo { bar(): void; }
+    // interface Foo { bar: string; }
+    if (
+      (path.isObjectTypeProperty() || path.isTSTypeElement()) &&
+      (path.parentPath.isObjectTypeAnnotation() || path.parentPath.isTSInterfaceBody()) &&
+      (path.parentPath.parentPath.isInterfaceDeclaration() || path.parentPath.parentPath.isTSInterfaceDeclaration())
+    ) {
+      return inferMembershipFromIdentifiers(
+        comment,
+        inferClassMembership(path.parentPath.parentPath),
+        'instance'
       );
     }
 

--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -2,7 +2,7 @@ const t = require('@babel/types');
 const generate = require('@babel/generator').default;
 const _ = require('lodash');
 const finders = require('./finders');
-const flowDoctrine = require('../flow_doctrine');
+const typeAnnotation = require('../type_annotation');
 
 /**
  * Infers param tags by reading function parameter names
@@ -129,7 +129,7 @@ function paramToDoc(param, prefix, i) {
           title: 'param',
           name: autoName,
           anonymous: true,
-          type: (param.typeAnnotation && flowDoctrine(param)) || {
+          type: (param.typeAnnotation && typeAnnotation(param)) || {
             type: 'NameExpression',
             name: 'Object'
           },
@@ -145,7 +145,7 @@ function paramToDoc(param, prefix, i) {
           title: 'param',
           name: prefixedName,
           anonymous: true,
-          type: (param.typeAnnotation && flowDoctrine(param)) || {
+          type: (param.typeAnnotation && typeAnnotation(param)) || {
             type: 'NameExpression',
             name: 'Object'
           },
@@ -169,7 +169,7 @@ function paramToDoc(param, prefix, i) {
           title: 'param',
           name: autoName,
           anonymous: true,
-          type: (param.typeAnnotation && flowDoctrine(param)) || {
+          type: (param.typeAnnotation && typeAnnotation(param)) || {
             type: 'NameExpression',
             name: 'Array'
           },
@@ -211,7 +211,7 @@ function paramToDoc(param, prefix, i) {
         type: 'RestType'
       };
       if (param.typeAnnotation) {
-        type.expression = flowDoctrine(param.typeAnnotation.typeAnnotation);
+        type.expression = typeAnnotation(param.typeAnnotation);
       }
       return {
         title: 'param',
@@ -230,7 +230,7 @@ function paramToDoc(param, prefix, i) {
 
       // Flow/TS annotations
       if (param.typeAnnotation && param.typeAnnotation.typeAnnotation) {
-        newParam.type = flowDoctrine(param.typeAnnotation.typeAnnotation);
+        newParam.type = typeAnnotation(param.typeAnnotation.typeAnnotation);
       }
 
       return newParam;

--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -37,7 +37,7 @@ function inferParams(comment) {
     }
   }
 
-  if (!t.isFunction(path)) {
+  if (!t.isFunction(path) && !t.isTSDeclareFunction(path) && !t.isTSDeclareMethod(path)) {
     return comment;
   }
 

--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -163,7 +163,7 @@ function paramToDoc(param, prefix, i) {
           title: 'param',
           name: autoName,
           anonymous: true,
-          type: (param.typeAnnotation && typeAnnotation(param)) || {
+          type: (param.typeAnnotation && typeAnnotation(param.typeAnnotation)) || {
             type: 'NameExpression',
             name: 'Object'
           },
@@ -179,7 +179,7 @@ function paramToDoc(param, prefix, i) {
           title: 'param',
           name: prefixedName,
           anonymous: true,
-          type: (param.typeAnnotation && typeAnnotation(param)) || {
+          type: (param.typeAnnotation && typeAnnotation(param.typeAnnotation)) || {
             type: 'NameExpression',
             name: 'Object'
           },
@@ -203,7 +203,7 @@ function paramToDoc(param, prefix, i) {
           title: 'param',
           name: autoName,
           anonymous: true,
-          type: (param.typeAnnotation && typeAnnotation(param)) || {
+          type: (param.typeAnnotation && typeAnnotation(param.typeAnnotation)) || {
             type: 'NameExpression',
             name: 'Array'
           },

--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -49,7 +49,17 @@ function inferParams(comment) {
 }
 
 function inferAndCombineParams(params, comment) {
-  const inferredParams = params.map((param, i) => paramToDoc(param, '', i));
+  const inferredParams = params.map((param, i) => {
+    const doc = paramToDoc(param, '', i);
+    if (param.optional) {
+      return {
+        type: 'OptionalType',
+        expression: doc
+      };
+    }
+
+    return doc;
+  });
   const paramsToMerge = comment.params;
   if (comment.constructorComment) {
     paramsToMerge.push.apply(paramsToMerge, comment.constructorComment.params);

--- a/src/infer/properties.js
+++ b/src/infer/properties.js
@@ -52,13 +52,6 @@ function inferProperties(comment) {
           comment.properties = comment.properties.concat(
             propertyToDoc(property, prefix)
           );
-
-          // Nested type parameters
-          if (property.value && property.value.type === 'ObjectTypeAnnotation') {
-            inferProperties(property.value, prefix.concat(property.key.name));
-          } else if (property.typeAnnotation && property.typeAnnotation.type === 'TSTypeAnnotation' && property.typeAnnotation.typeAnnotation.type === 'TSTypeLiteral') {
-            inferProperties(property.typeAnnotation.typeAnnotation, prefix.concat(property.key.name));
-          }
         }
       });
     }

--- a/src/infer/return.js
+++ b/src/infer/return.js
@@ -43,17 +43,18 @@ function inferReturn(comment) {
     fn = fn.init;
   }
 
-  if ((t.isFunction(fn) || t.isTSDeclareFunction(fn) || t.isTSDeclareMethod(fn)) && fn.returnType) {
-    let returnType = typeAnnotation(fn.returnType);
+  const fnReturnType = getReturnType(fn);
+  if (fnReturnType) {
+    let returnType = typeAnnotation(fnReturnType);
     let yieldsType = null;
 
     if (fn.generator && returnType.type === 'TypeApplication') {
       comment.generator = true;
       let numArgs;
 
-      if (t.isFlow(fn.returnType)) {
+      if (t.isFlow(fnReturnType)) {
         numArgs = FLOW_GENERATORS[returnType.expression.name];
-      } else if (t.isTSTypeAnnotation(fn.returnType)) {
+      } else if (t.isTSTypeAnnotation(fnReturnType)) {
         numArgs = TS_GENERATORS[returnType.expression.name];
       }
 
@@ -95,6 +96,16 @@ function inferReturn(comment) {
     }
   }
   return comment;
+}
+
+function getReturnType(fn) {
+  if (t.isFunction(fn) || t.isTSDeclareFunction(fn) || t.isTSDeclareMethod(fn) || t.isFunctionTypeAnnotation(fn)) {
+    return fn.returnType;
+  }
+
+  if (t.isTSMethodSignature(fn)) {
+    return fn.typeAnnotation;
+  }
 }
 
 module.exports = inferReturn;

--- a/src/infer/return.js
+++ b/src/infer/return.js
@@ -1,6 +1,6 @@
 const findTarget = require('./finders').findTarget;
 const t = require('@babel/types');
-const flowDoctrine = require('../flow_doctrine');
+const typeAnnotation = require('../flow_doctrine');
 
 /**
  * Infers returns tags by using Flow return type annotations
@@ -30,7 +30,7 @@ function inferReturn(comment) {
   }
 
   if (t.isFunction(fn) && fn.returnType && fn.returnType.typeAnnotation) {
-    let returnType = flowDoctrine(fn.returnType.typeAnnotation);
+    let returnType = typeAnnotation(fn.returnType.typeAnnotation);
     if (comment.returns && comment.returns.length > 0) {
       comment.returns[0].type = returnType;
     } else {

--- a/src/infer/return.js
+++ b/src/infer/return.js
@@ -43,7 +43,7 @@ function inferReturn(comment) {
     fn = fn.init;
   }
 
-  if (t.isFunction(fn) && fn.returnType) {
+  if ((t.isFunction(fn) || t.isTSDeclareFunction(fn) || t.isTSDeclareMethod(fn)) && fn.returnType) {
     let returnType = typeAnnotation(fn.returnType);
     if (comment.returns && comment.returns.length > 0) {
       comment.returns[0].type = returnType;

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -1,6 +1,5 @@
 const findTarget = require('./finders').findTarget;
-const flowDoctrine = require('../flow_doctrine');
-const tsDoctrine = require('../ts_doctrine');
+const typeAnnotation = require('../type_annotation');
 const t = require('@babel/types');
 
 const constTypeMapping = {
@@ -50,15 +49,7 @@ function inferType(comment) {
       break;
   }
   if (type) {
-    if (t.isTSTypeAnnotation(type)) {
-      comment.type = tsDoctrine(type.typeAnnotation);
-    } else {
-      if (t.isTypeAnnotation(type)) {
-        type = type.typeAnnotation;
-      }
-
-      comment.type = flowDoctrine(type);
-    }
+    comment.type = typeAnnotation(type);
   }
   return comment;
 }

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -47,6 +47,9 @@ function inferType(comment) {
     case 'TypeAlias':
       type = n.right;
       break;
+    case 'TSTypeAliasDeclaration':
+      type = n.typeAnnotation;
+      break;
   }
   if (type) {
     comment.type = typeAnnotation(type);

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -1,6 +1,5 @@
 const findTarget = require('./finders').findTarget;
 const typeAnnotation = require('../type_annotation');
-const t = require('@babel/types');
 
 const constTypeMapping = {
   BooleanLiteral: { type: 'BooleanTypeAnnotation' },

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -50,6 +50,15 @@ function inferType(comment) {
     case 'TypeAlias':
       type = n.right;
       break;
+    case 'TSEnumMember':
+      if (n.initializer) {
+        if (constTypeMapping[n.initializer.type]) {
+          type = constTypeMapping[n.initializer.type];
+        }
+      } else {
+        type = constTypeMapping.NumericLiteral;
+      }
+      break;
     default:
       if (ast.isObjectTypeProperty() && !ast.node.method) {
         type = ast.node.value;

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -19,7 +19,8 @@ function inferType(comment) {
     return comment;
   }
 
-  const path = findTarget(comment.context.ast);
+  const ast = comment.context.ast;
+  const path = findTarget(ast);
   if (!path) {
     return comment;
   }
@@ -34,6 +35,8 @@ function inferType(comment) {
       }
       break;
     case 'ClassProperty':
+    case 'TSTypeAliasDeclaration':
+    case 'TSPropertySignature':
       type = n.typeAnnotation;
       break;
     case 'ClassMethod':
@@ -47,9 +50,10 @@ function inferType(comment) {
     case 'TypeAlias':
       type = n.right;
       break;
-    case 'TSTypeAliasDeclaration':
-      type = n.typeAnnotation;
-      break;
+    default:
+      if (ast.isObjectTypeProperty() && !ast.node.method) {
+        type = ast.node.value;
+      }
   }
   if (type) {
     comment.type = typeAnnotation(type);

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -37,6 +37,7 @@ function inferType(comment) {
       type = n.typeAnnotation;
       break;
     case 'ClassMethod':
+    case 'TSDeclareMethod':
       if (n.kind === 'get') {
         type = n.returnType;
       } else if (n.kind === 'set' && n.params[0]) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -171,7 +171,14 @@ const flatteners = {
   hideconstructor: flattenBoolean,
   host: synonym('external'),
   ignore: flattenBoolean,
-  implements: todo,
+  implements(result, tag) {
+    // Match @extends/@augments above.
+    if (!tag.name && tag.type && tag.type.name) {
+      tag.name = tag.type.name;
+    }
+
+    result.implements.push(tag);
+  },
   inheritdoc: todo,
   /**
    * Parse tag
@@ -608,6 +615,7 @@ function parseJSDoc(comment, loc, context) {
   result.augments = [];
   result.errors = [];
   result.examples = [];
+  result.implements = [];
   result.params = [];
   result.properties = [];
   result.returns = [];

--- a/src/parse.js
+++ b/src/parse.js
@@ -82,7 +82,10 @@ const flatteners = {
   desc: synonym('description'),
   description: flattenMarkdownDescription,
   emits: synonym('fires'),
-  enum: todo,
+  enum(result, tag) {
+    result.kind = 'enum';
+    result.type = tag.type;
+  },
   /**
    * Parse tag
    * @private
@@ -206,7 +209,7 @@ const flatteners = {
    * @returns {undefined} has side-effects
    */
   interface(result, tag) {
-    result.interface = true;
+    result.kind = 'interface';
     if (tag.description) {
       result.name = tag.description;
     }

--- a/src/parsers/javascript.js
+++ b/src/parsers/javascript.js
@@ -36,7 +36,7 @@ function parseJavaScript(data, config) {
   const visited = new Set();
   const commentsByNode = new Map();
 
-  const ast = parseToAst(data.source);
+  const ast = parseToAst(data.source, data.file);
   const addComment = _addComment.bind(null, visited, commentsByNode);
 
   return _.flatMap(

--- a/src/parsers/parse_to_ast.js
+++ b/src/parsers/parse_to_ast.js
@@ -1,27 +1,35 @@
 const babelParser = require('@babel/parser');
+const path = require('path');
 
-const opts = {
-  allowImportExportEverywhere: true,
-  sourceType: 'module',
-  plugins: [
-    'asyncGenerators',
-    'exportDefaultFrom',
-    'optionalChaining',
-    'classConstructorCall',
-    'classPrivateProperties',
-    'classProperties',
-    ['decorators', { decoratorsBeforeExport: false }],
-    'doExpressions',
-    'exportExtensions',
-    'flow',
-    'functionBind',
-    'functionSent',
-    'jsx',
-    'objectRestSpread',
-    'dynamicImport',
-    'logicalAssignment'
-  ]
+const TYPESCRIPT_EXTS = {
+  '.ts': true,
+  '.tsx': true
 };
+
+function getParserOpts(file) {
+  return {
+    allowImportExportEverywhere: true,
+    sourceType: 'module',
+    plugins: [
+      'asyncGenerators',
+      'exportDefaultFrom',
+      'optionalChaining',
+      'classConstructorCall',
+      'classPrivateProperties',
+      'classProperties',
+      ['decorators', { decoratorsBeforeExport: false }],
+      'doExpressions',
+      'exportExtensions',
+      TYPESCRIPT_EXTS[path.extname(file || '')] ? 'typescript' : 'flow',
+      'functionBind',
+      'functionSent',
+      'jsx',
+      'objectRestSpread',
+      'dynamicImport',
+      'logicalAssignment'
+    ]
+  };
+}
 
 /**
  * Convert flow comment types into flow annotations so that
@@ -37,8 +45,8 @@ function commentToFlow(source) {
     .replace(/\/\*:\s*([^]+?)\s*\*\//g, ':$1');
 }
 
-function parseToAst(source) {
-  return babelParser.parse(commentToFlow(source), opts);
+function parseToAst(source, file) {
+  return babelParser.parse(commentToFlow(source), getParserOpts(file));
 }
 module.exports.commentToFlow = commentToFlow;
 module.exports.parseToAst = parseToAst;

--- a/src/ts_doctrine.js
+++ b/src/ts_doctrine.js
@@ -1,0 +1,177 @@
+const generate = require('@babel/generator').default;
+
+const namedTypes = {
+  TSNumberKeyword: 'number',
+  TSBooleanKeyword: 'boolean',
+  TSStringKeyword: 'string',
+  TSSymbolKeyword: 'symbol',
+  TSThisType: 'this',
+  TSObjectKeyword: 'object',
+  TSNeverKeyword: 'never'
+};
+
+const oneToOne = {
+  TSAnyKeyword: 'AllLiteral',
+  TSUnknownKeyword: 'AllLiteral',
+  TSNullKeyword: 'NullLiteral',
+  TSUndefinedKeyword: 'UndefinedLiteral',
+  TSVoidKeyword: 'VoidLiteral'
+};
+
+function propertyToField(property) {
+  if (!property.typeAnnotation) return null;
+
+  let type = tsDoctrine(property.typeAnnotation.typeAnnotation);
+  if (property.optional) {
+    // Doctrine does not support optional fields but it does have something called optional types
+    // (which makes no sense, but let's play along).
+    type = {
+      type: 'OptionalType',
+      expression: type
+    };
+  }
+  return {
+    type: 'FieldType',
+    key: property.key.name || property.key.value,
+    value: type
+  };
+}
+
+/**
+ * Babel parses TypeScript annotations in JavaScript into AST nodes. documentation.js uses
+ * Babel to parse TypeScript. This method restructures those Babel-generated
+ * objects into objects that fit the output of Doctrine, the module we use
+ * to parse JSDoc annotations. This lets us use TypeScript annotations _as_
+ * JSDoc annotations.
+ *
+ * @private
+ * @param {Object} type babel-parsed typescript type
+ * @returns {Object} doctrine compatible type
+ */
+function tsDoctrine(type) {
+  if (type.type in namedTypes) {
+    const doctrineType = {
+      type: 'NameExpression',
+      name: namedTypes[type.type]
+    };
+    return doctrineType;
+  }
+
+  // TODO: unhandled types
+  // TSIntersectionType, TSConditionalType, TSInferType, TSTypeOperator, TSIndexedAccessType
+  // TSMappedType, TSImportType, TSTypePredicate, TSTypeQuery, TSExpressionWithTypeArguments
+
+  if (type.type in oneToOne) {
+    return { type: oneToOne[type.type] };
+  }
+
+  switch (type.type) {
+    case 'TSOptionalType':
+      return {
+        type: 'NullableType',
+        expression: tsDoctrine(type.typeAnnotation)
+      };
+    case 'TSParenthesizedType':
+      return tsDoctrine(type.typeAnnotation);
+    case 'TSUnionType':
+      return {
+        type: 'UnionType',
+        elements: type.types.map(tsDoctrine)
+      };
+    // [number]
+    // [string, boolean, number]
+    case 'TSTupleType':
+      return {
+        type: 'ArrayType',
+        elements: type.elementTypes.map(tsDoctrine)
+      };
+    // number[]
+    case 'TSArrayType':
+      return {
+        type: 'TypeApplication',
+        expression: {
+          type: 'NameExpression',
+          name: 'Array'
+        },
+        applications: [tsDoctrine(type.elementType)]
+      };
+    // ...string
+    case 'TSRestType':
+      return {
+        type: 'RestType',
+        expression: tsDoctrine(type.typeAnnotation)
+      };
+    // (y: number) => bool
+    case 'TSFunctionType':
+    case 'TSConstructorType':
+      return {
+        type: 'FunctionType',
+        params: type.parameters.map(param => {
+          if (param.type === 'RestElement') {
+            return {
+              type: 'RestType',
+              expression: {
+                type: 'ParameterType',
+                name: param.argument.name,
+                expression: tsDoctrine(param.typeAnnotation.typeAnnotation)
+              }
+            };
+          }
+
+          return {
+            type: 'ParameterType',
+            name: param.name,
+            expression: tsDoctrine(param.typeAnnotation.typeAnnotation)
+          };
+        }),
+        result: tsDoctrine(type.typeAnnotation.typeAnnotation)
+      };
+
+    case 'TSTypeReference':
+      if (type.typeParameters) {
+        return {
+          type: 'TypeApplication',
+          expression: {
+            type: 'NameExpression',
+            name: generate(type.typeName, {
+              compact: true
+            }).code
+          },
+          applications: type.typeParameters.params.map(tsDoctrine)
+        };
+      }
+
+      return {
+        type: 'NameExpression',
+        name: generate(type.typeName, {
+          compact: true
+        }).code
+      };
+
+    case 'TSTypeLiteral':
+      if (type.members) {
+        return {
+          type: 'RecordType',
+          fields: type.members.map(propertyToField).filter(x => x)
+        };
+      }
+
+      return {
+        type: 'NameExpression',
+        name: generate(type.id, {
+          compact: true
+        }).code
+      };
+    case 'TSLiteralType':
+      return {
+        type: `${type.literal.type}Type`,
+        value: type.literal.value
+      };
+    default:
+      return {
+        type: 'AllLiteral'
+      };
+  }
+}
+
+module.exports = tsDoctrine;

--- a/src/ts_doctrine.js
+++ b/src/ts_doctrine.js
@@ -104,6 +104,7 @@ function tsDoctrine(type) {
     // (y: number) => bool
     case 'TSFunctionType':
     case 'TSConstructorType':
+    case 'TSMethodSignature':
       return {
         type: 'FunctionType',
         params: type.parameters.map(param => {

--- a/src/type_annotation.js
+++ b/src/type_annotation.js
@@ -3,15 +3,19 @@ const flowDoctrine = require('./flow_doctrine');
 const tsDoctrine = require('./ts_doctrine');
 
 function typeAnnotation(type) {
-  if (t.isTSTypeAnnotation(type)) {
-    return tsDoctrine(type.typeAnnotation);
+  if (t.isFlow(type)) {
+    if (t.isTypeAnnotation(type)) {
+      type = type.typeAnnotation;
+    }
+  
+    return flowDoctrine(type);  
   }
   
-  if (t.isTypeAnnotation(type)) {
+  if (t.isTSTypeAnnotation(type)) {
     type = type.typeAnnotation;
   }
 
-  return flowDoctrine(type);
+  return tsDoctrine(type);
 }
 
 module.exports = typeAnnotation;

--- a/src/type_annotation.js
+++ b/src/type_annotation.js
@@ -1,0 +1,17 @@
+const t = require('@babel/types');
+const flowDoctrine = require('./flow_doctrine');
+const tsDoctrine = require('./ts_doctrine');
+
+function typeAnnotation(type) {
+  if (t.isTSTypeAnnotation(type)) {
+    return tsDoctrine(type.typeAnnotation);
+  }
+  
+  if (t.isTypeAnnotation(type)) {
+    type = type.typeAnnotation;
+  }
+
+  return flowDoctrine(type);
+}
+
+module.exports = typeAnnotation;


### PR DESCRIPTION
Related: #282.

This PR adds TypeScript support to documentationjs, using Babel 7's TypeScript parsing support. This is enabled automatically when a file with a `.ts` or `.tsx` extension is seen. Similar to the Flow support, TypeScript annotations are converted to Doctrine compatible values. A wrapper function to handle all Babel-parsed type annotations and convert to Doctrine was added for this.

In addition to converting types, inference was added for most TypeScript constructs including access modifiers, abstract classes, getters/setters, function/method params and return types, type alias and interface properties, etc.

There are a few advanced constructs in TypeScript that cannot be directly converted to Doctrine types. I'm not really sure what to do about them:

* Type parameters (generics)
* Intersection types
* Conditional types
* Inferred types
* Indexed types
* Mapped types
* Import types
* Type queries and predicates

Perhaps we can start with basic support, and figure out how to get support for these in after the initial implementation is complete. Some of these also have Flow equivalents which are already unhandled by documentationjs.

Full list of TypeScript AST nodes (from babel) is below. Some of them can still be added, others like the above listed categories will be more challenging due to limitations of Doctrine, and others may not be necessary for a documentation generator to support.

- [ ] TSParameterProperty
- [ ] TSDeclareFunction
- [x] TSDeclareMethod
- [x] TSQualifiedName
- [ ] TSCallSignatureDeclaration
- [x] TSPropertySignature
  - [x] optional
  - [x] readonly
  - [x] typeAnnotation
- [x] TSMethodSignature
  - [ ] typeParameters
  - [x] parameters
  - [x] typeAnnotation
  - [x] optional
- [ ] TSIndexSignature
- [x] TSAnyKeyword
- [x] TSUnknownKeyword
- [x] TSNumberKeyword
- [x] TSObjectKeyword
- [x] TSBooleanKeyword
- [x] TSStringKeyword
- [x] TSSymbolKeyword
- [x] TSVoidKeyword
- [x] TSUndefinedKeyword
- [x] TSNullKeyword
- [x] TSNeverKeyword
- [x] TSThisType
- [x] TSFunctionType
  - [ ] typeParameters
  - [x] parameters
  - [x] typeAnnotation
- [x] TSConstructorType
  - [ ] typeParameters
  - [x] parameters
  - [x] typeAnnotation
- [x] TSTypeReference
  - [x] typeName
  - [x] typeParameters
- [ ] TSTypePredicate
- [ ] TSTypeQuery
- [x] TSTypeLiteral
- [x] TSArrayType
- [x] TSTupleType
- [x] TSOptionalType
- [x] TSRestType
- [x] TSUnionType
- [ ] TSIntersectionType
- [ ] TSConditionalType
- [ ] TSInferType
- [x] TSParenthesizedType
- [ ] TSTypeOperator
- [ ] TSIndexedAccessType
- [ ] TSMappedType
- [x] TSLiteralType
- [ ] TSExpressionWithTypeArguments
- [x] TSInterfaceDeclaration
  - [ ] typeParameters
  - [x] extends
  - [x] body
- [x] TSInterfaceBody
- [x] TSTypeAliasDeclaration
  - [ ] typeParameters
  - [x] typeAnnotation
- [ ] TSAsExpression
- [ ] TSTypeAssertion
- [x] TSEnumDeclaration
- [x] TSEnumMember
- [x] TSModuleDeclaration
- [ ] TSModuleBlock
- [ ] TSImportType
- [ ] TSImportEqualsDeclaration
- [ ] TSExternalModuleReference
- [ ] TSNonNullExpression
- [ ] TSExportAssignment
- [ ] TSNamespaceExportDeclaration
- [x] TSTypeAnnotation
- [ ] TSTypeParameterInstantiation
- [ ] TSTypeParameterDeclaration
- [ ] TSTypeParameter

Additional JSDoc tags with equivalents in TypeScript (and Flow) that are not yet supported:

- [x] `@implements`
- [x] `@enum`
