### PR TITLE
fix: Crash when called with no inputs. 

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -43,7 +43,7 @@ module.exports.handler = function build(argv) {
   let watcher;
   argv._handled = true;
 
-  if (!argv.input.length) {
+  if (!(argv.input && argv.input.length)) {
     try {
       argv.input = [
         JSON.parse(fs.readFileSync(path.resolve('package.json'), 'utf8'))


### PR DESCRIPTION
yargs now variadic positional arguments undefined instead of []

Fixes #1259