### PR TITLE
fix: Allow skipped array arguments in destructuring

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -8529,7 +8529,7 @@ have any parameter descriptions.",
     "context": Object {
       "loc": Object {
         "end": Object {
-          "column": 34,
+          "column": 36,
           "line": 16,
         },
         "start": Object {
@@ -8593,7 +8593,7 @@ have any parameter descriptions.",
     "errors": Array [],
     "examples": Array [
       Object {
-        "description": "destructure([1, 2, 3])",
+        "description": "destructure([0, 1, 2, 3])",
       },
     ],
     "implements": Array [],
@@ -8623,7 +8623,6 @@ have any parameter descriptions.",
         "name": "$0",
         "properties": Array [
           Object {
-            "lineNumber": 16,
             "name": "$0.0",
             "title": "param",
           },
@@ -8635,6 +8634,11 @@ have any parameter descriptions.",
           Object {
             "lineNumber": 16,
             "name": "$0.2",
+            "title": "param",
+          },
+          Object {
+            "lineNumber": 16,
+            "name": "$0.3",
             "title": "param",
           },
         ],
@@ -8656,7 +8660,7 @@ have any parameter descriptions.",
     "sees": Array [],
     "tags": Array [
       Object {
-        "description": "destructure([1, 2, 3])",
+        "description": "destructure([0, 1, 2, 3])",
         "lineNumber": 2,
         "title": "example",
       },
@@ -11631,11 +11635,12 @@ Similar, but with an array
     -   \`$0.0\`  
     -   \`$0.1\`  
     -   \`$0.2\`  
+    -   \`$0.3\`  
 
 ### Examples
 
 \`\`\`javascript
-destructure([1, 2, 3])
+destructure([0, 1, 2, 3])
 \`\`\`
 
 ## multiply
@@ -12271,6 +12276,28 @@ have any parameter descriptions.",
                   ],
                   "type": "listItem",
                 },
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "inlineCode",
+                          "value": "$0.3",
+                        },
+                        Object {
+                          "type": "text",
+                          "value": " ",
+                        },
+                        Object {
+                          "type": "text",
+                          "value": " ",
+                        },
+                      ],
+                      "type": "paragraph",
+                    },
+                  ],
+                  "type": "listItem",
+                },
               ],
               "ordered": false,
               "type": "list",
@@ -12295,7 +12322,7 @@ have any parameter descriptions.",
     Object {
       "lang": "javascript",
       "type": "code",
-      "value": "destructure([1, 2, 3])",
+      "value": "destructure([0, 1, 2, 3])",
     },
     Object {
       "children": Array [

--- a/__tests__/fixture/es6.input.js
+++ b/__tests__/fixture/es6.input.js
@@ -11,9 +11,9 @@ function destructure({
 /**
  * Similar, but with an array
  * @example
- * destructure([1, 2, 3])
+ * destructure([0, 1, 2, 3])
  */
-function destructure([a, b, c]) {}
+function destructure([, a, b, c]) {}
 
 /**
  * This function returns the number one.
@@ -184,6 +184,6 @@ class A {
     // nullishCoalescingOperator
     let x = a ?? b;
     // logicalAssignment
-    return x &&= b?.b |> String.fromCharCode;
+    return (x &&= b?.b |> String.fromCharCode);
   }
 }

--- a/src/infer/params.js
+++ b/src/infer/params.js
@@ -273,7 +273,10 @@ function paramToDoc(param, prefix, i) {
       const newParam = {
         title: 'param',
         name: prefix ? prefixedName : param.name,
-        lineNumber: param.loc.start.line
+        // A skipped array argument like ([, a]);
+        // looks like { name: '0', indexed: true }, and thus has no location,
+        // so we allow location to be undefined here.
+        lineNumber: param.loc ? param.loc.start.line : undefined
       };
 
       // Flow/TS annotations


### PR DESCRIPTION
- Fixes #1247