### PR TITLE
fix: Git submodule support for repo names with a dot

### DIFF
--- a/__tests__/lib/git/find_git.js
+++ b/__tests__/lib/git/find_git.js
@@ -16,11 +16,17 @@ test('findGit', function() {
   });
 
   mock(mockRepo.submodule);
-  const submodulePaths = findGit(path.join(root, 'index.js'));
+  const submoduleRoot = path.join(root, '..', 'my.submodule');
+  const submodulePaths = findGit(path.join(submoduleRoot, 'index.js'));
   mock.restore();
 
   expect(submodulePaths).toEqual({
-    git: path.join(path.dirname(root), '.git', 'modules', 'path'),
-    root
+    git: path.join(
+      path.dirname(submoduleRoot),
+      '.git',
+      'modules',
+      'my.submodule'
+    ),
+    root: submoduleRoot
   });
 });

--- a/__tests__/lib/git/url_prefix.js
+++ b/__tests__/lib/git/url_prefix.js
@@ -26,8 +26,8 @@ test('getGithubURLPrefix', function() {
 
   mock(mockRepo.submodule);
   const submoduleUrl = getGithubURLPrefix({
-    git: '/my/repository/.git/modules/path',
-    root: '/my/repository/path'
+    git: '/my/repository/.git/modules/my.submodule',
+    root: '/my/repository/my.submodule'
   });
   mock.restore();
 

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -77,17 +77,17 @@ module.exports.mockRepo = {
   submodule: {
     '/my': {
       repository: {
-        path: {
-          '.git': 'gitdir: ../.git/modules/path',
+        'my.submodule': {
+          '.git': 'gitdir: ../.git/modules/my.submodule',
           'index.js': 'module.exports = 42;'
         },
         '.git': {
           config:
-            '[submodule "path"]\n' +
+            '[submodule "my.submodule"]\n' +
             'url = https://github.com/foo/bar\n' +
             'active = true',
           modules: {
-            path: {
+            'my.submodule': {
               HEAD: 'ref: refs/heads/master',
               refs: {
                 heads: {

--- a/src/git/url_prefix.js
+++ b/src/git/url_prefix.js
@@ -59,14 +59,10 @@ function getGithubURLPrefix({ git, root }) {
     if (sha) {
       let origin;
       if (git.indexOf(root) === 0) {
-        const config = ini.parse(
-          fs.readFileSync(path.join(git, 'config'), 'utf8')
-        );
+        const config = parseGitConfig(path.join(git, 'config'));
         origin = config['remote "origin"'].url;
       } else {
-        const config = ini.parse(
-          fs.readFileSync(path.join(git, '..', '..', 'config'), 'utf8')
-        );
+        const config = parseGitConfig(path.join(git, '..', '..', 'config'));
         origin = config[`submodule "${path.basename(git)}"`].url;
       }
       const parsed = gitUrlParse(origin);
@@ -76,6 +72,16 @@ function getGithubURLPrefix({ git, root }) {
   } catch (e) {
     return null;
   }
+}
+
+function parseGitConfig(configPath) {
+  const str = fs
+    .readFileSync(configPath, 'utf8')
+    .replace(
+      /\[(\S+) "(.+)"\]/g,
+      (match, key, value) => `[${key} "${value.split('.').join('\\.')}"]`
+    );
+  return ini.parse(str);
 }
 
 module.exports = getGithubURLPrefix;


### PR DESCRIPTION
Fixes git submodule handling for repos containing `.` in the name. Addresses https://github.com/documentationjs/documentation/pull/1270#discussion_r309464612