### PR TITLE
Fix check for empty diff

### DIFF
--- a/src/commands/readme.js
+++ b/src/commands/readme.js
@@ -101,7 +101,7 @@ module.exports.handler = function readme(argv) {
         '',
         ''
       );
-      if (!diffRaw.length) {
+      if (diffRaw.length === 4) {
         log(`${argv.readmeFile} is up to date.`);
         process.exit(0);
       }

--- a/src/commands/readme.js
+++ b/src/commands/readme.js
@@ -101,7 +101,7 @@ module.exports.handler = function readme(argv) {
         '',
         ''
       );
-      if (diffRaw.length === 4) {
+      if (diffRaw.split('\n').length === 5) {
         log(`${argv.readmeFile} is up to date.`);
         process.exit(0);
       }


### PR DESCRIPTION
Compare to the result of the latest diff module: https://runkit.com/embed/y4qzdzzz05qr

No diff currently gives this result:

```
Index: 
===================================================================
--- 	
+++ 	
```

But the current check expect it to result in an empty string, causing the `--diff-only` flag in the readme CLI to fail.