### PR TITLE
disable spellcheck, autocorrect and autocapitalize on the filter input

### DIFF
--- a/src/default_theme/index._
+++ b/src/default_theme/index._
@@ -21,6 +21,9 @@
             placeholder='Filter'
             id='filter-input'
             class='col12 block input'
+            spellcheck='false'
+            autocapitalize='off'
+            autocorrect='off'
             type='text' />
           <div id='toc'>
             <ul class='list-reset h5 py1-ul'>


### PR DESCRIPTION
the text entered here are likely to be functions and technical terms and as such spellcheck, autocapitalize and autocorrect would better be disabled.