### PR TITLE
Fix a crash in ts_doctrine.js

### DIFF
--- a/src/ts_doctrine.js
+++ b/src/ts_doctrine.js
@@ -32,7 +32,7 @@ function propertyToField(property) {
   }
   return {
     type: 'FieldType',
-    key: property.key.name || property.key.value,
+    key: property.key ? property.key.name || property.key.value : '',
     value: type
   };
 }


### PR DESCRIPTION
Alright, this is just an one-liner simply fixing a patch but that's the easiest thing I can do with our keybase-bot codebase.

The following command triggers the crash when you run it on keybase-bot:

```
documentation.js readme 'src/**/*.ts' --config documentation.yml --require-extension=.ts --parse-extension=.ts --section=API --shallow
```

This is totally unrelated to another bug which happens when you run it without `shallow`:

```
documentation.js readme 'src/**/*.ts' --config documentation.yml --require-extension=.ts --parse-extension=.ts --section=API
```

I have no clue what ts_doctrine's output means and how to work with it so I went with the simplest fix. Unfortunately that still doesn't fix most of our issues but at least it generates docs without crashing.

Related to #1260 