### PR TITLE
Reduce npm package by removing development files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,9 @@
 circle.yml
 coverage
 __tests__
+.circleci
+.github
+.prettierignore
+.prettierrc
+CODE_OF_CONDUCT.md
+ISSUE_TEMPLATE.md


### PR DESCRIPTION
I added more files to `.npmignore` to keep `node_modules` small