### PR TITLE
refactor: 💡 type section is redundant and not formatted

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -5209,65 +5209,6 @@ Array [
     "context": Object {
       "loc": Object {
         "end": Object {
-          "column": 28,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 28,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "x",
-    "namespace": "x",
-    "params": Array [
-      Object {
-        "lineNumber": 1,
-        "name": "yparam",
-        "title": "param",
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "x",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
           "column": 1,
           "line": 3,
         },
@@ -5367,6 +5308,65 @@ Array [
       Object {
         "kind": "class",
         "name": "z",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
+          "column": 28,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 28,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "x",
+    "namespace": "x",
+    "params": Array [
+      Object {
+        "lineNumber": 1,
+        "name": "yparam",
+        "title": "param",
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "x",
       },
     ],
     "properties": Array [],
@@ -7078,10 +7078,10 @@ exports[`outputs document-exported.input.js markdown 1`] = `
 
 ### Table of Contents
 
--   [x][1]
-    -   [Parameters][2]
--   [z][3]
-    -   [zMethod][4]
+-   [z][1]
+    -   [zMethod][2]
+-   [x][3]
+    -   [Parameters][4]
 -   [Class][5]
     -   [Parameters][6]
     -   [classMethod][7]
@@ -7117,15 +7117,15 @@ exports[`outputs document-exported.input.js markdown 1`] = `
 -   [o2][37]
     -   [om2][38]
 
+## z
+
+### zMethod
+
 ## x
 
 ### Parameters
 
 -   \`yparam\`  
-
-## z
-
-### zMethod
 
 ## Class
 
@@ -7223,13 +7223,13 @@ f5 comment
 
 ### om2
 
-[1]: #x
+[1]: #z
 
-[2]: #parameters
+[2]: #zmethod
 
-[3]: #z
+[3]: #x
 
-[4]: #zmethod
+[4]: #parameters
 
 [5]: #class
 
@@ -7318,6 +7318,26 @@ Object {
       "children": Array [
         Object {
           "type": "text",
+          "value": "z",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "zMethod",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
           "value": "x",
         },
       ],
@@ -7361,26 +7381,6 @@ Object {
       ],
       "ordered": false,
       "type": "list",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "z",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "zMethod",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
     },
     Object {
       "children": Array [
@@ -31972,30 +31972,6 @@ Array [
     "tags": Array [],
     "throws": Array [],
     "todos": Array [],
-    "type": Object {
-      "fields": Array [
-        Object {
-          "key": "opt",
-          "type": "FieldType",
-          "value": Object {
-            "expression": Object {
-              "name": "number",
-              "type": "NameExpression",
-            },
-            "type": "OptionalType",
-          },
-        },
-        Object {
-          "key": "req",
-          "type": "FieldType",
-          "value": Object {
-            "name": "string",
-            "type": "NameExpression",
-          },
-        },
-      ],
-      "type": "RecordType",
-    },
     "yields": Array [],
   },
 ]
@@ -32010,8 +31986,6 @@ exports[`outputs optional-record-field-type.input.js markdown 1`] = `
     -   [Properties][2]
 
 ## Record
-
-Type: {opt: [number][3]?, req: [string][4]}
 
 ### Properties
 
@@ -32044,61 +32018,6 @@ Object {
       ],
       "depth": 2,
       "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Type: ",
-        },
-        Object {
-          "type": "text",
-          "value": "{",
-        },
-        Object {
-          "type": "text",
-          "value": "opt: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "number",
-            },
-          ],
-          "identifier": "1",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": "?",
-        },
-        Object {
-          "type": "text",
-          "value": ", ",
-        },
-        Object {
-          "type": "text",
-          "value": "req: ",
-        },
-        Object {
-          "children": Array [
-            Object {
-              "type": "text",
-              "value": "string",
-            },
-          ],
-          "identifier": "2",
-          "referenceType": "full",
-          "type": "linkReference",
-        },
-        Object {
-          "type": "text",
-          "value": "}",
-        },
-      ],
-      "type": "paragraph",
     },
     Object {
       "children": Array [

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -5209,6 +5209,65 @@ Array [
     "context": Object {
       "loc": Object {
         "end": Object {
+          "column": 28,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 0,
+          "line": 1,
+        },
+      },
+    },
+    "description": "",
+    "errors": Array [],
+    "examples": Array [],
+    "implements": Array [],
+    "kind": "function",
+    "loc": Object {
+      "end": Object {
+        "column": 28,
+        "line": 1,
+      },
+      "start": Object {
+        "column": 0,
+        "line": 1,
+      },
+    },
+    "members": Object {
+      "events": Array [],
+      "global": Array [],
+      "inner": Array [],
+      "instance": Array [],
+      "static": Array [],
+    },
+    "name": "x",
+    "namespace": "x",
+    "params": Array [
+      Object {
+        "lineNumber": 1,
+        "name": "yparam",
+        "title": "param",
+      },
+    ],
+    "path": Array [
+      Object {
+        "kind": "function",
+        "name": "x",
+      },
+    ],
+    "properties": Array [],
+    "returns": Array [],
+    "sees": Array [],
+    "tags": Array [],
+    "throws": Array [],
+    "todos": Array [],
+    "yields": Array [],
+  },
+  Object {
+    "augments": Array [],
+    "context": Object {
+      "loc": Object {
+        "end": Object {
           "column": 1,
           "line": 3,
         },
@@ -5308,65 +5367,6 @@ Array [
       Object {
         "kind": "class",
         "name": "z",
-      },
-    ],
-    "properties": Array [],
-    "returns": Array [],
-    "sees": Array [],
-    "tags": Array [],
-    "throws": Array [],
-    "todos": Array [],
-    "yields": Array [],
-  },
-  Object {
-    "augments": Array [],
-    "context": Object {
-      "loc": Object {
-        "end": Object {
-          "column": 28,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 0,
-          "line": 1,
-        },
-      },
-    },
-    "description": "",
-    "errors": Array [],
-    "examples": Array [],
-    "implements": Array [],
-    "kind": "function",
-    "loc": Object {
-      "end": Object {
-        "column": 28,
-        "line": 1,
-      },
-      "start": Object {
-        "column": 0,
-        "line": 1,
-      },
-    },
-    "members": Object {
-      "events": Array [],
-      "global": Array [],
-      "inner": Array [],
-      "instance": Array [],
-      "static": Array [],
-    },
-    "name": "x",
-    "namespace": "x",
-    "params": Array [
-      Object {
-        "lineNumber": 1,
-        "name": "yparam",
-        "title": "param",
-      },
-    ],
-    "path": Array [
-      Object {
-        "kind": "function",
-        "name": "x",
       },
     ],
     "properties": Array [],
@@ -7078,10 +7078,10 @@ exports[`outputs document-exported.input.js markdown 1`] = `
 
 ### Table of Contents
 
--   [z][1]
-    -   [zMethod][2]
--   [x][3]
-    -   [Parameters][4]
+-   [x][1]
+    -   [Parameters][2]
+-   [z][3]
+    -   [zMethod][4]
 -   [Class][5]
     -   [Parameters][6]
     -   [classMethod][7]
@@ -7117,15 +7117,15 @@ exports[`outputs document-exported.input.js markdown 1`] = `
 -   [o2][37]
     -   [om2][38]
 
-## z
-
-### zMethod
-
 ## x
 
 ### Parameters
 
 -   \`yparam\`  
+
+## z
+
+### zMethod
 
 ## Class
 
@@ -7223,13 +7223,13 @@ f5 comment
 
 ### om2
 
-[1]: #z
+[1]: #x
 
-[2]: #zmethod
+[2]: #parameters
 
-[3]: #x
+[3]: #z
 
-[4]: #parameters
+[4]: #zmethod
 
 [5]: #class
 
@@ -7318,26 +7318,6 @@ Object {
       "children": Array [
         Object {
           "type": "text",
-          "value": "z",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "zMethod",
-        },
-      ],
-      "depth": 3,
-      "type": "heading",
-    },
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
           "value": "x",
         },
       ],
@@ -7381,6 +7361,26 @@ Object {
       ],
       "ordered": false,
       "type": "list",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "z",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "zMethod",
+        },
+      ],
+      "depth": 3,
+      "type": "heading",
     },
     Object {
       "children": Array [

--- a/__tests__/lib/infer/type.js
+++ b/__tests__/lib/infer/type.js
@@ -41,28 +41,6 @@ test('inferType (flow)', function() {
     type: 'TypeApplication'
   });
 
-  expect(evaluate('/** */' + "type V = {a:number,'b':string}").type).toEqual({
-    fields: [
-      {
-        key: 'a',
-        type: 'FieldType',
-        value: {
-          name: 'number',
-          type: 'NameExpression'
-        }
-      },
-      {
-        key: 'b',
-        type: 'FieldType',
-        value: {
-          name: 'string',
-          type: 'NameExpression'
-        }
-      }
-    ],
-    type: 'RecordType'
-  });
-
   expect(evaluate('/** */' + 'type V = Array<T>').type).toEqual({
     applications: [
       {
@@ -127,16 +105,12 @@ test('inferType (flow)', function() {
     type: 'NameExpression'
   });
 
-  expect(
-    evaluate('interface Foo { /** */ bar: string; }').type
-  ).toEqual({
+  expect(evaluate('interface Foo { /** */ bar: string; }').type).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
 
-  expect(
-    evaluate('type Foo = { /** */ bar: string; }').type
-  ).toEqual({
+  expect(evaluate('type Foo = { /** */ bar: string; }').type).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
@@ -165,28 +139,6 @@ test('inferType (typescript)', function() {
       type: 'NameExpression'
     },
     type: 'TypeApplication'
-  });
-
-  expect(evaluate('/** */' + "type V = {a:number,'b':string}", 'test.ts').type).toEqual({
-    fields: [
-      {
-        key: 'a',
-        type: 'FieldType',
-        value: {
-          name: 'number',
-          type: 'NameExpression'
-        }
-      },
-      {
-        key: 'b',
-        type: 'FieldType',
-        value: {
-          name: 'string',
-          type: 'NameExpression'
-        }
-      }
-    ],
-    type: 'RecordType'
   });
 
   expect(evaluate('/** */' + 'type V = Array<T>', 'test.ts').type).toEqual({
@@ -223,27 +175,43 @@ test('inferType (typescript)', function() {
     type: 'NameExpression'
   });
 
-  expect(evaluate('class C {' + '/** */' + 'x: number;' + '}', 'test.ts').type).toEqual({
+  expect(
+    evaluate('class C {' + '/** */' + 'x: number;' + '}', 'test.ts').type
+  ).toEqual({
     name: 'number',
     type: 'NameExpression'
   });
 
-  expect(evaluate('class Foo { /** */ get b(): string { } }', 'test.ts').type).toEqual({
+  expect(
+    evaluate('class Foo { /** */ get b(): string { } }', 'test.ts').type
+  ).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
 
-  expect(evaluate('class Foo { /** */ set b(s: string) { } }', 'test.ts').type).toEqual({
+  expect(
+    evaluate('class Foo { /** */ set b(s: string) { } }', 'test.ts').type
+  ).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
 
-  expect(evaluate('abstract class Foo { /** */ abstract get b(): string; }', 'test.ts').type).toEqual({
+  expect(
+    evaluate(
+      'abstract class Foo { /** */ abstract get b(): string; }',
+      'test.ts'
+    ).type
+  ).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
 
-  expect(evaluate('abstract class Foo { /** */ abstract set b(s: string); }', 'test.ts').type).toEqual({
+  expect(
+    evaluate(
+      'abstract class Foo { /** */ abstract set b(s: string); }',
+      'test.ts'
+    ).type
+  ).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
@@ -277,28 +245,22 @@ test('inferType (typescript)', function() {
     type: 'NameExpression'
   });
 
-  expect(
-    evaluate('enum Foo { /** */ A }', 'test.ts').type
-  ).toEqual({
+  expect(evaluate('enum Foo { /** */ A }', 'test.ts').type).toEqual({
     name: 'number',
     type: 'NameExpression'
   });
 
-  expect(
-    evaluate('enum Foo { /** */ A = 2 }', 'test.ts').type
-  ).toEqual({
+  expect(evaluate('enum Foo { /** */ A = 2 }', 'test.ts').type).toEqual({
     name: 'number',
     type: 'NameExpression'
   });
 
-  expect(
-    evaluate('enum Foo { /** */ A = "test" }', 'test.ts').type
-  ).toEqual({
+  expect(evaluate('enum Foo { /** */ A = "test" }', 'test.ts').type).toEqual({
     name: 'string',
     type: 'NameExpression'
   });
 
-  expect(
-    evaluate('enum Foo { /** */ A = foo }', 'test.ts').type
-  ).toBe(undefined);
+  expect(evaluate('enum Foo { /** */ A = foo }', 'test.ts').type).toBe(
+    undefined
+  );
 });

--- a/src/infer/type.js
+++ b/src/infer/type.js
@@ -64,7 +64,9 @@ function inferType(comment) {
         type = ast.node.value;
       }
   }
-  if (type) {
+  // Don't provide a `type` section when it's an ObjectTypeAnnotation,
+  // `properties` already exists and renders better.
+  if (type && type.type !== 'ObjectTypeAnnotation') {
     comment.type = typeAnnotation(type);
   }
   return comment;


### PR DESCRIPTION
When an object is flow typed, a `type` AND `properties` section is
rendered. The type section seems redundant and isn't formatted, whereas
the properties section is. This PR removes the `type` section when
dealing with an object type.

✅ Closes: #1326