### PR TITLE
fix: Additional safety around detecting functions in HTML output

### DIFF
--- a/src/default_theme/index.js
+++ b/src/default_theme/index.js
@@ -13,6 +13,7 @@ function isFunction(section) {
   return (
     section.kind === 'function' ||
     (section.kind === 'typedef' &&
+      section.type &&
       section.type.type === 'NameExpression' &&
       section.type.name === 'Function')
   );


### PR DESCRIPTION
This is another particular corner where we made an unsafe assumption that `section.type` existed, so in the case where it was null but kind was typedef, crash.