### PR TITLE
Add TypeScript usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ documentation readme index.js --section=API
 # build docs for all values exported by index.js
 documentation build --document-exported index.js
 
+# build html docs for a TypeScript project
+documentation build index.ts --parse-extension ts -f html -o docs
+
 Commands:
   serve [input..]   generate, update, and display HTML documentation
   build [input..]   build documentation


### PR DESCRIPTION
Thanks to @SantoJambit for pointing out in #1272 the need for the `--parse-extension ts` argument to build docs for TypeScript projects.