### PR TITLE
chore(ci) : setup dependency updates with dependatbot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly 


### PR DESCRIPTION
This setup dependabot to handle npm weekly update of the dependencies.
Replaces #1385 