### PR TITLE
fix: use process.cwd vs `.` which can fail

### DIFF
--- a/src/commands/readme.js
+++ b/src/commands/readme.js
@@ -11,7 +11,7 @@ import getReadmeFile from '../get-readme-file.js';
 const command = 'readme [input..]';
 const description = 'inject documentation into your README.md';
 
-const defaultReadmeFile = getReadmeFile('.');
+const defaultReadmeFile = getReadmeFile(process.cwd());
 
 /**
  * Add yargs parsing for the readme command


### PR DESCRIPTION
When '.' does not work, this utility function outside the runtime closure can yield an unhelpful error for consumers.