### PR TITLE
correctly sort undefined values

### DIFF
--- a/__tests__/lib/__snapshots__/sort.js.snap
+++ b/__tests__/lib/__snapshots__/sort.js.snap
@@ -156,6 +156,13 @@ exports[`sort toc with files absolute path 3`] = `
 Array [
   Object {
     "context": Object {
+      "sortKey": "b",
+    },
+    "memberof": "classB",
+    "name": "carrot",
+  },
+  Object {
+    "context": Object {
       "sortKey": "a",
     },
     "kind": "function",
@@ -169,13 +176,6 @@ Array [
     "kind": "function",
     "memberof": "classB",
     "name": "bananas",
-  },
-  Object {
-    "context": Object {
-      "sortKey": "b",
-    },
-    "memberof": "classB",
-    "name": "carrot",
   },
 ]
 `;

--- a/src/sort.js
+++ b/src/sort.js
@@ -110,6 +110,8 @@ function compareCommentsByField(field, a, b) {
   if (akey && bkey) {
     return akey.localeCompare(bkey, undefined, { caseFirst: 'upper' });
   }
+  if (akey) return 1;
+  if (bkey) return -1;
   return 0;
 }
 


### PR DESCRIPTION
This PR fixes sorting of undefined values - before they were randomly intermingled inbetween the rest because `1 < undefined === false` && `1 > undefined === false`

Normally, no element should have an undefined `kind` - this PR simply moves them all to the top where they will be immediately seen