### PR TITLE
Bump mock-fs from 5.1.2 to 5.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "jest": "^28.1.3",
         "json-schema": "^0.4.0",
         "lint-staged": "^13.0.3",
-        "mock-fs": "^5.1.2",
+        "mock-fs": "^5.1.3",
         "prettier": "^2.7.1",
         "standard-version": "^9.5.0",
         "tmp": "^0.2.1"
@@ -9040,9 +9040,9 @@
       }
     },
     "node_modules/mock-fs": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
-      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.3.tgz",
+      "integrity": "sha512-6rAOGeJgXFYsHlRSsuwUsSIPHk3sA4JfCOLswTc0gSFIU6HTC2xaRXh14orYKYLAg5ygmnxaYsrRxC4xNUkxnw==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -18222,9 +18222,9 @@
       }
     },
     "mock-fs": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
-      "integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.3.tgz",
+      "integrity": "sha512-6rAOGeJgXFYsHlRSsuwUsSIPHk3sA4JfCOLswTc0gSFIU6HTC2xaRXh14orYKYLAg5ygmnxaYsrRxC4xNUkxnw==",
       "dev": true
     },
     "modify-values": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "jest": "^28.1.3",
         "json-schema": "^0.4.0",
         "lint-staged": "^13.0.3",
-        "mock-fs": "^5.1.3",
+        "mock-fs": "^5.1.4",
         "prettier": "^2.7.1",
         "standard-version": "^9.5.0",
         "tmp": "^0.2.1"
@@ -9040,9 +9040,9 @@
       }
     },
     "node_modules/mock-fs": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.3.tgz",
-      "integrity": "sha512-6rAOGeJgXFYsHlRSsuwUsSIPHk3sA4JfCOLswTc0gSFIU6HTC2xaRXh14orYKYLAg5ygmnxaYsrRxC4xNUkxnw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.4.tgz",
+      "integrity": "sha512-sudhLjCjX37qWIcAlIv1OnAxB2wI4EmXByVuUjILh1rKGNGpGU8GNnzw+EAbrhdpBe0TL/KONbK1y3RXZk8SxQ==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -18222,9 +18222,9 @@
       }
     },
     "mock-fs": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.3.tgz",
-      "integrity": "sha512-6rAOGeJgXFYsHlRSsuwUsSIPHk3sA4JfCOLswTc0gSFIU6HTC2xaRXh14orYKYLAg5ygmnxaYsrRxC4xNUkxnw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.4.tgz",
+      "integrity": "sha512-sudhLjCjX37qWIcAlIv1OnAxB2wI4EmXByVuUjILh1rKGNGpGU8GNnzw+EAbrhdpBe0TL/KONbK1y3RXZk8SxQ==",
       "dev": true
     },
     "modify-values": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^28.1.3",
     "json-schema": "^0.4.0",
     "lint-staged": "^13.0.3",
-    "mock-fs": "^5.1.3",
+    "mock-fs": "^5.1.4",
     "prettier": "^2.7.1",
     "standard-version": "^9.5.0",
     "tmp": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^28.1.3",
     "json-schema": "^0.4.0",
     "lint-staged": "^13.0.3",
-    "mock-fs": "^5.1.2",
+    "mock-fs": "^5.1.3",
     "prettier": "^2.7.1",
     "standard-version": "^9.5.0",
     "tmp": "^0.2.1"


### PR DESCRIPTION
The 5.1.3 patch version introduced a bug related to BigInt that breaks the test, so we jump directly to 5.1.4