### PR TITLE
Update membership.js

### DIFF
--- a/src/infer/membership.js
+++ b/src/infer/membership.js
@@ -91,7 +91,10 @@ function extractThis(path, comment) {
         scope = scope.parent;
       }
 
-      if (n.isClassMethod(scope.block)) {
+      if (
+        n.isClassMethod(scope.block) &&
+        scope.path.parentPath.parentPath.node.id !== null
+      ) {
         identifiers.push(
           scope.path.parentPath.parentPath.node.id.name,
           'prototype'


### PR DESCRIPTION
Stops this error from happening:
TypeError: Cannot read properties of null (reading 'name')
    at ThisExpression (file:///C:/Users/dev/Documents/Projects/fc-pregmod/node_modules/documentation/src/infer/membership.js:98:54)
    at NodePath._call (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\path\context.js:46:20)
    at NodePath.call (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\path\context.js:36:17)
    at NodePath.visit (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\path\context.js:82:31)
    at TraversalContext.visitQueue (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\context.js:86:16)
    at TraversalContext.visitSingle (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\context.js:65:19)
    at TraversalContext.visit (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\context.js:109:19)
    at traverseNode (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\traverse-node.js:22:17)
    at traverse (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\index.js:52:34)
    at NodePath.traverse (C:\Users\dev\Documents\Projects\fc-pregmod\node_modules\@babel\traverse\lib\path\index.js:101:24)